### PR TITLE
agent:feat(sandcastle): detect and report blocked-reason on issue

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -259,6 +259,34 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 
   let branch = implement.branch;
 
+  const blockedReasonMatch = implement.stdout.match(
+    /<blocked-reason>([\s\S]*?)<\/blocked-reason>/
+  );
+  if (blockedReasonMatch) {
+    const blockedReason = blockedReasonMatch?.[1]?.trim() ?? '';
+    console.log('\nAgent is blocked.');
+    console.log(`Reason: ${blockedReason}`);
+
+    // Post the blocked reason as a comment on the issue.
+    const workingOnMatch = implement.stdout.match(
+      /<working-on-issue>(\d+)<\/working-on-issue>/
+    );
+    const issueNumber = workingOnMatch?.[1];
+    if (issueNumber) {
+      try {
+        execSync(
+          `gh issue comment ${issueNumber} --body ${JSON.stringify(blockedReason)}`,
+          { stdio: 'inherit' }
+        );
+        console.log(`Posted blocked reason on issue #${issueNumber}.`);
+      } catch {
+        console.warn(`Could not post comment on issue #${issueNumber}.`);
+      }
+    }
+
+    continue;
+  }
+
   if (!implement.commits.length) {
     console.log('Implementation agent made no commits. Skipping review.');
     continue;

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -263,7 +263,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     /<blocked-reason>([\s\S]*?)<\/blocked-reason>/
   );
   if (blockedReasonMatch) {
-    const blockedReason = blockedReasonMatch?.[1]?.trim() ?? '';
+    const blockedReason = blockedReasonMatch[1]?.trim() ?? '';
     console.log('\nAgent is blocked.');
     console.log(`Reason: ${blockedReason}`);
 


### PR DESCRIPTION
Parse `<blocked-reason>` tag from implementer stdout after the implement phase. If found, post the reason as a comment on the corresponding GitHub issue using `gh issue comment`, then skip review and PR phases for that iteration via `continue`. This ensures there is a record of why the agent got stuck, and a human can reply on the issue to unblock the next autonomous run.

Closes #130