### PR TITLE
refactor(www): rename preview exports to {DirPascal}{Suffix} (#156)

### DIFF
--- a/apps/www/docs/previews/avatar/avatar-size.tsx
+++ b/apps/www/docs/previews/avatar/avatar-size.tsx
@@ -1,6 +1,6 @@
 import { Avatar, AvatarImage, AvatarFallback } from '@/registry/ui/avatar';
 
-export function Default() {
+export function AvatarDefault() {
   return (
     <Avatar>
       <AvatarImage
@@ -12,9 +12,9 @@ export function Default() {
   );
 }
 
-export default Default;
+export default AvatarDefault;
 
-export function Sm() {
+export function AvatarSm() {
   return (
     <Avatar size="sm">
       <AvatarImage
@@ -26,7 +26,7 @@ export function Sm() {
   );
 }
 
-export function Lg() {
+export function AvatarLg() {
   return (
     <Avatar size="lg">
       <AvatarImage

--- a/apps/www/docs/previews/badge/badge-theme.tsx
+++ b/apps/www/docs/previews/badge/badge-theme.tsx
@@ -1,23 +1,23 @@
 import { Badge } from '@/registry/ui/badge';
 
-export function Gray() {
+export function BadgeGray() {
   return <Badge theme="gray">Badge</Badge>;
 }
 
-export function Accent() {
+export function BadgeAccent() {
   return <Badge theme="accent">Badge</Badge>;
 }
 
-export function Destructive() {
+export function BadgeDestructive() {
   return <Badge theme="destructive">Badge</Badge>;
 }
 
-export function Warning() {
+export function BadgeWarning() {
   return <Badge theme="warning">Badge</Badge>;
 }
 
-export function Success() {
+export function BadgeSuccess() {
   return <Badge theme="success">Badge</Badge>;
 }
 
-export default Gray;
+export default BadgeGray;

--- a/apps/www/docs/previews/badge/badge-variants.tsx
+++ b/apps/www/docs/previews/badge/badge-variants.tsx
@@ -1,19 +1,19 @@
 import { Badge } from '@/registry/ui/badge';
 
-export function Solid() {
+export function BadgeSolid() {
   return <Badge variant="solid">Badge</Badge>;
 }
 
-export function Outline() {
+export function BadgeOutline() {
   return <Badge variant="outline">Badge</Badge>;
 }
 
-export function Surface() {
+export function BadgeSurface() {
   return <Badge variant="surface">Badge</Badge>;
 }
 
-export function Soft() {
+export function BadgeSoft() {
   return <Badge variant="soft">Badge</Badge>;
 }
 
-export default Solid;
+export default BadgeSolid;

--- a/apps/www/docs/previews/badge/badge-with-icon.tsx
+++ b/apps/www/docs/previews/badge/badge-with-icon.tsx
@@ -1,7 +1,7 @@
 import { StarIcon } from '@heroicons/react/16/solid';
 import { Badge } from '@/registry/ui/badge';
 
-export function Leading() {
+export function BadgeLeading() {
   return (
     <Badge>
       <StarIcon />
@@ -10,7 +10,7 @@ export function Leading() {
   );
 }
 
-export function Trailing() {
+export function BadgeTrailing() {
   return (
     <Badge>
       Featured
@@ -19,4 +19,4 @@ export function Trailing() {
   );
 }
 
-export default Leading;
+export default BadgeLeading;

--- a/apps/www/docs/previews/button/button-theme.tsx
+++ b/apps/www/docs/previews/button/button-theme.tsx
@@ -1,15 +1,15 @@
 import { Button } from '@/registry/ui/button';
 
-export function Gray() {
+export function ButtonGray() {
   return <Button theme="gray">Cancel</Button>;
 }
 
-export function Accent() {
+export function ButtonAccent() {
   return <Button theme="accent">Cancel</Button>;
 }
 
-export function Destructive() {
+export function ButtonDestructive() {
   return <Button theme="destructive">Cancel</Button>;
 }
 
-export default Gray;
+export default ButtonGray;

--- a/apps/www/docs/previews/button/button-variants.tsx
+++ b/apps/www/docs/previews/button/button-variants.tsx
@@ -1,23 +1,23 @@
 import { Button } from '@/registry/ui/button';
 
-export function Solid() {
+export function ButtonSolid() {
   return <Button variant="solid">Sign up</Button>;
 }
 
-export function Outline() {
+export function ButtonOutline() {
   return <Button variant="outline">Sign up</Button>;
 }
 
-export function Surface() {
+export function ButtonSurface() {
   return <Button variant="surface">Sign up</Button>;
 }
 
-export function Soft() {
+export function ButtonSoft() {
   return <Button variant="soft">Sign up</Button>;
 }
 
-export function Ghost() {
+export function ButtonGhost() {
   return <Button variant="ghost">Sign up</Button>;
 }
 
-export default Solid;
+export default ButtonSolid;

--- a/apps/www/docs/previews/button/button-with-icon.tsx
+++ b/apps/www/docs/previews/button/button-with-icon.tsx
@@ -1,7 +1,7 @@
 import { PlusCircleIcon } from '@heroicons/react/16/solid';
 import { Button } from '@/registry/ui/button';
 
-export function Leading() {
+export function ButtonLeading() {
   return (
     <Button>
       <PlusCircleIcon />
@@ -10,7 +10,7 @@ export function Leading() {
   );
 }
 
-export function Trailing() {
+export function ButtonTrailing() {
   return (
     <Button>
       Create New
@@ -19,4 +19,4 @@ export function Trailing() {
   );
 }
 
-export default Leading;
+export default ButtonLeading;

--- a/apps/www/docs/previews/checkbox-group/checkbox-group-theme.tsx
+++ b/apps/www/docs/previews/checkbox-group/checkbox-group-theme.tsx
@@ -7,7 +7,7 @@ const GENRES = [
   { value: 'hip-hop', label: 'Hip-Hop' },
 ];
 
-export function Gray() {
+export function CheckboxGroupGray() {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-sm font-medium text-foreground">Pick a genre</p>
@@ -23,7 +23,7 @@ export function Gray() {
   );
 }
 
-export function Accent() {
+export function CheckboxGroupAccent() {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-sm font-medium text-foreground">Pick a genre</p>
@@ -39,4 +39,4 @@ export function Accent() {
   );
 }
 
-export default Gray;
+export default CheckboxGroupGray;

--- a/apps/www/docs/previews/checkbox-group/checkbox-group-variant.tsx
+++ b/apps/www/docs/previews/checkbox-group/checkbox-group-variant.tsx
@@ -7,7 +7,7 @@ const GENRES = [
   { value: 'hip-hop', label: 'Hip-Hop' },
 ];
 
-export function Solid() {
+export function CheckboxGroupSolid() {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-sm font-medium text-foreground">Pick a genre</p>
@@ -23,7 +23,7 @@ export function Solid() {
   );
 }
 
-export function Surface() {
+export function CheckboxGroupSurface() {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-sm font-medium text-foreground">Pick a genre</p>
@@ -39,4 +39,4 @@ export function Surface() {
   );
 }
 
-export default Solid;
+export default CheckboxGroupSolid;

--- a/apps/www/docs/previews/checkbox/checkbox-theme.tsx
+++ b/apps/www/docs/previews/checkbox/checkbox-theme.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from '@/registry/ui/checkbox';
 
-export function Gray() {
+export function CheckboxGray() {
   return (
     <label className="flex items-center gap-2">
       <Checkbox theme="gray" defaultChecked />
@@ -9,7 +9,7 @@ export function Gray() {
   );
 }
 
-export function Accent() {
+export function CheckboxAccent() {
   return (
     <label className="flex items-center gap-2">
       <Checkbox theme="accent" defaultChecked />
@@ -18,4 +18,4 @@ export function Accent() {
   );
 }
 
-export default Gray;
+export default CheckboxGray;

--- a/apps/www/docs/previews/checkbox/checkbox-variant.tsx
+++ b/apps/www/docs/previews/checkbox/checkbox-variant.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from '@/registry/ui/checkbox';
 
-export function Solid() {
+export function CheckboxSolid() {
   return (
     <label className="flex items-center gap-2">
       <Checkbox variant="solid" defaultChecked />
@@ -9,7 +9,7 @@ export function Solid() {
   );
 }
 
-export function Surface() {
+export function CheckboxSurface() {
   return (
     <label className="flex items-center gap-2">
       <Checkbox variant="surface" defaultChecked />
@@ -18,4 +18,4 @@ export function Surface() {
   );
 }
 
-export default Solid;
+export default CheckboxSolid;

--- a/apps/www/docs/previews/dropdown-menu/dropdown-menu-theme.tsx
+++ b/apps/www/docs/previews/dropdown-menu/dropdown-menu-theme.tsx
@@ -30,12 +30,12 @@ function EditMenu({ theme }: { theme: 'gray' | 'accent' }) {
   );
 }
 
-export function Gray() {
+export function DropdownMenuGray() {
   return <EditMenu theme="gray" />;
 }
 
-export function Accent() {
+export function DropdownMenuAccent() {
   return <EditMenu theme="accent" />;
 }
 
-export default Gray;
+export default DropdownMenuGray;

--- a/apps/www/docs/previews/dropdown-menu/dropdown-menu-variant.tsx
+++ b/apps/www/docs/previews/dropdown-menu/dropdown-menu-variant.tsx
@@ -30,12 +30,12 @@ function EditMenu({ variant }: { variant: 'soft' | 'solid' }) {
   );
 }
 
-export function Soft() {
+export function DropdownMenuSoft() {
   return <EditMenu variant="soft" />;
 }
 
-export function Solid() {
+export function DropdownMenuSolid() {
   return <EditMenu variant="solid" />;
 }
 
-export default Soft;
+export default DropdownMenuSoft;

--- a/apps/www/docs/previews/input/input-variant.tsx
+++ b/apps/www/docs/previews/input/input-variant.tsx
@@ -1,15 +1,15 @@
 import { Input } from '@/registry/ui/input';
 
-export function Surface() {
+export function InputSurface() {
   return <Input placeholder="Email address" />;
 }
 
-export function Outline() {
+export function InputOutline() {
   return <Input variant="outline" placeholder="Email address" />;
 }
 
-export function Soft() {
+export function InputSoft() {
   return <Input variant="soft" placeholder="Email address" />;
 }
 
-export default Surface;
+export default InputSurface;

--- a/apps/www/docs/previews/kbd/kbd-variant.tsx
+++ b/apps/www/docs/previews/kbd/kbd-variant.tsx
@@ -2,16 +2,16 @@
 
 import { Kbd } from '@/registry/ui/kbd';
 
-export function Soft() {
+export function KbdSoft() {
   return <Kbd variant="soft">K</Kbd>;
 }
 
-export function Surface() {
+export function KbdSurface() {
   return <Kbd variant="surface">K</Kbd>;
 }
 
-export function Ghost() {
+export function KbdGhost() {
   return <Kbd variant="ghost">K</Kbd>;
 }
 
-export default Soft;
+export default KbdSoft;

--- a/apps/www/docs/previews/radio-group/radio-group-variant.tsx
+++ b/apps/www/docs/previews/radio-group/radio-group-variant.tsx
@@ -2,7 +2,7 @@
 
 import { RadioGroup, RadioGroupItem } from '@/registry/ui/radio-group';
 
-export function Solid() {
+export function RadioGroupSolid() {
   return (
     <RadioGroup defaultValue="a" className="w-48">
       <label className="flex cursor-pointer items-center gap-2 text-sm text-primary">
@@ -17,7 +17,7 @@ export function Solid() {
   );
 }
 
-export function Surface() {
+export function RadioGroupSurface() {
   return (
     <RadioGroup defaultValue="a" className="w-48">
       <label className="flex cursor-pointer items-center gap-2 text-sm text-primary">
@@ -32,4 +32,4 @@ export function Surface() {
   );
 }
 
-export default Solid;
+export default RadioGroupSolid;

--- a/apps/www/docs/previews/registry.ts
+++ b/apps/www/docs/previews/registry.ts
@@ -9,29 +9,32 @@ import AlertDialogDefault from './alert-dialog/alert-dialog-default';
 import AlertDialogWithIcon from './alert-dialog/alert-dialog-with-icon';
 import AvatarHero from './avatar/avatar-hero';
 import AvatarDefault from './avatar/avatar-default';
-import AvatarSizeDefault, { Sm as AvatarSizeSm, Lg as AvatarSizeLg } from './avatar/avatar-size';
+import AvatarSizeDefault, {
+  AvatarSm as AvatarSizeSm,
+  AvatarLg as AvatarSizeLg,
+} from './avatar/avatar-size';
 import AvatarWithBadge from './avatar/avatar-with-badge';
 import AvatarGroup from './avatar/avatar-group';
 import CheckboxHero from './checkbox/checkbox-hero';
 import CheckboxDefault from './checkbox/checkbox-default';
 import CheckboxVariantDefault, {
-  Solid as CheckboxVariantSolid,
-  Surface as CheckboxVariantSurface,
+  CheckboxSolid as CheckboxVariantSolid,
+  CheckboxSurface as CheckboxVariantSurface,
 } from './checkbox/checkbox-variant';
 import CheckboxThemeDefault, {
-  Gray as CheckboxThemeGray,
-  Accent as CheckboxThemeAccent,
+  CheckboxGray as CheckboxThemeGray,
+  CheckboxAccent as CheckboxThemeAccent,
 } from './checkbox/checkbox-theme';
 import CheckboxIndeterminate from './checkbox/checkbox-indeterminate';
 import CheckboxGroupHero from './checkbox-group/checkbox-group-hero';
 import CheckboxGroupDefault from './checkbox-group/checkbox-group-default';
 import CheckboxGroupVariantDefault, {
-  Solid as CheckboxGroupVariantSolid,
-  Surface as CheckboxGroupVariantSurface,
+  CheckboxGroupSolid as CheckboxGroupVariantSolid,
+  CheckboxGroupSurface as CheckboxGroupVariantSurface,
 } from './checkbox-group/checkbox-group-variant';
 import CheckboxGroupThemeDefault, {
-  Gray as CheckboxGroupThemeGray,
-  Accent as CheckboxGroupThemeAccent,
+  CheckboxGroupGray as CheckboxGroupThemeGray,
+  CheckboxGroupAccent as CheckboxGroupThemeAccent,
 } from './checkbox-group/checkbox-group-theme';
 import CheckboxGroupParent from './checkbox-group/checkbox-group-parent';
 import CheckboxGroupNested from './checkbox-group/checkbox-group-nested';
@@ -42,39 +45,39 @@ import FormHero from './form/form-hero';
 import FormProduct from './form/form-product';
 import InputHero from './input/input-hero';
 import InputVariantDefault, {
-  Outline as InputVariantOutline,
-  Soft as InputVariantSoft,
+  InputOutline as InputVariantOutline,
+  InputSoft as InputVariantSoft,
 } from './input/input-variant';
 import KbdHero from './kbd/kbd-hero';
 import KbdCombination from './kbd/kbd-combination';
 import KbdVariantDefault, {
-  Ghost as KbdVariantGhost,
-  Surface as KbdVariantSurface,
+  KbdGhost as KbdVariantGhost,
+  KbdSurface as KbdVariantSurface,
 } from './kbd/kbd-variant';
 import RadioGroupHero from './radio-group/radio-group-hero';
 import RadioGroupVariantDefault, {
-  Surface as RadioGroupVariantSurface,
+  RadioGroupSurface as RadioGroupVariantSurface,
 } from './radio-group/radio-group-variant';
 import SeparatorHero from './separator/separator-hero';
 import SeparatorVertical from './separator/separator-vertical';
 import SeparatorHorizontal from './separator/separator-horizontal';
 import ToggleGroupHero from './toggle-group/toggle-group-hero';
 import ToggleGroupVariantsDefault, {
-  Outline as ToggleGroupVariantsOutline,
-  Solid as ToggleGroupVariantsSolid,
+  ToggleGroupOutline as ToggleGroupVariantsOutline,
+  ToggleGroupSolid as ToggleGroupVariantsSolid,
 } from './toggle-group/toggle-group-variants';
 import ToggleGroupConnected from './toggle-group/toggle-group-connected';
 import ToggleGroupVertical from './toggle-group/toggle-group-vertical';
 import SwitchHero from './switch/switch-hero';
 import SwitchWithLabel from './switch/switch-with-label';
 import SwitchThemeDefault, {
-  Gray as SwitchThemeGray,
-  Accent as SwitchThemeAccent,
+  SwitchGray as SwitchThemeGray,
+  SwitchAccent as SwitchThemeAccent,
 } from './switch/switch-theme';
 import TabsHero from './tabs/tabs-hero';
 import TabsVariantsDefault, {
-  Soft as TabsVariantsSoft,
-  Solid as TabsVariantsSolid,
+  TabsSoft as TabsVariantsSoft,
+  TabsSolid as TabsVariantsSolid,
 } from './tabs/tabs-variants';
 import TabsOrientation from './tabs/tabs-orientation';
 import TabsWithSurface from './tabs/tabs-with-surface';
@@ -84,29 +87,29 @@ import TabsTransition from './tabs/tabs-transition';
 import DropdownMenuHero from './dropdown-menu/dropdown-menu-hero';
 import DropdownMenuBasic from './dropdown-menu/dropdown-menu-basic';
 import DropdownMenuVariantDefault, {
-  Soft as DropdownMenuVariantSoft,
-  Solid as DropdownMenuVariantSolid,
+  DropdownMenuSoft as DropdownMenuVariantSoft,
+  DropdownMenuSolid as DropdownMenuVariantSolid,
 } from './dropdown-menu/dropdown-menu-variant';
 import DropdownMenuThemeDefault, {
-  Gray as DropdownMenuThemeGray,
-  Accent as DropdownMenuThemeAccent,
+  DropdownMenuGray as DropdownMenuThemeGray,
+  DropdownMenuAccent as DropdownMenuThemeAccent,
 } from './dropdown-menu/dropdown-menu-theme';
 import ButtonHero from './button/button-hero';
 import ButtonVariantsDefault, {
-  Solid as ButtonVariantsSolid,
-  Outline as ButtonVariantsOutline,
-  Surface as ButtonVariantsSurface,
-  Soft as ButtonVariantsSoft,
-  Ghost as ButtonVariantsGhost,
+  ButtonSolid as ButtonVariantsSolid,
+  ButtonOutline as ButtonVariantsOutline,
+  ButtonSurface as ButtonVariantsSurface,
+  ButtonSoft as ButtonVariantsSoft,
+  ButtonGhost as ButtonVariantsGhost,
 } from './button/button-variants';
 import ButtonThemeDefault, {
-  Gray as ButtonThemeGray,
-  Accent as ButtonThemeAccent,
-  Destructive as ButtonThemeDestructive,
+  ButtonGray as ButtonThemeGray,
+  ButtonAccent as ButtonThemeAccent,
+  ButtonDestructive as ButtonThemeDestructive,
 } from './button/button-theme';
 import ButtonWithIconDefault, {
-  Leading as ButtonWithIconLeading,
-  Trailing as ButtonWithIconTrailing,
+  ButtonLeading as ButtonWithIconLeading,
+  ButtonTrailing as ButtonWithIconTrailing,
 } from './button/button-with-icon';
 import ButtonIconButton from './button/button-icon-button';
 import ButtonGroupHero from './button-group/button-group-hero';
@@ -118,33 +121,33 @@ import ButtonGroupWithSeparator from './button-group/button-group-with-separator
 import ButtonGroupWithText from './button-group/button-group-with-text';
 import BadgeHero from './badge/badge-hero';
 import BadgeVariantsDefault, {
-  Solid as BadgeVariantsSolid,
-  Outline as BadgeVariantsOutline,
-  Surface as BadgeVariantsSurface,
-  Soft as BadgeVariantsSoft,
+  BadgeSolid as BadgeVariantsSolid,
+  BadgeOutline as BadgeVariantsOutline,
+  BadgeSurface as BadgeVariantsSurface,
+  BadgeSoft as BadgeVariantsSoft,
 } from './badge/badge-variants';
 import BadgeThemeDefault, {
-  Gray as BadgeThemeGray,
-  Accent as BadgeThemeAccent,
-  Destructive as BadgeThemeDestructive,
-  Warning as BadgeThemeWarning,
-  Success as BadgeThemeSuccess,
+  BadgeGray as BadgeThemeGray,
+  BadgeAccent as BadgeThemeAccent,
+  BadgeDestructive as BadgeThemeDestructive,
+  BadgeWarning as BadgeThemeWarning,
+  BadgeSuccess as BadgeThemeSuccess,
 } from './badge/badge-theme';
 import BadgeWithIconDefault, {
-  Leading as BadgeWithIconLeading,
-  Trailing as BadgeWithIconTrailing,
+  BadgeLeading as BadgeWithIconLeading,
+  BadgeTrailing as BadgeWithIconTrailing,
 } from './badge/badge-with-icon';
 import BadgeIconOnly from './badge/badge-icon-only';
 import BadgeAsLink from './badge/badge-as-link';
 import ToggleHero from './toggle/toggle-hero';
 import ToggleVariantDefault, {
-  Outline as ToggleVariantOutline,
-  Solid as ToggleVariantSolid,
+  ToggleOutline as ToggleVariantOutline,
+  ToggleSolid as ToggleVariantSolid,
 } from './toggle/toggle-variant';
 import TextareaHero from './textarea/textarea-hero';
 import TextareaVariantDefault, {
-  Outline as TextareaVariantOutline,
-  Soft as TextareaVariantSoft,
+  TextareaOutline as TextareaVariantOutline,
+  TextareaSoft as TextareaVariantSoft,
 } from './textarea/textarea-variant';
 import TextareaManualResize from './textarea/textarea-manual-resize';
 import TextareaWithLabel from './textarea/textarea-with-label';

--- a/apps/www/docs/previews/switch/switch-theme.tsx
+++ b/apps/www/docs/previews/switch/switch-theme.tsx
@@ -1,11 +1,11 @@
 import { Switch } from '@/registry/ui/switch';
 
-export function Gray() {
+export function SwitchGray() {
   return <Switch defaultChecked />;
 }
 
-export function Accent() {
+export function SwitchAccent() {
   return <Switch theme="accent" defaultChecked />;
 }
 
-export default Gray;
+export default SwitchGray;

--- a/apps/www/docs/previews/tabs/tabs-variants.tsx
+++ b/apps/www/docs/previews/tabs/tabs-variants.tsx
@@ -1,6 +1,6 @@
 import { Tabs, TabsList, TabsTab, TabsPanel } from '@/registry/ui/tabs';
 
-export function Soft() {
+export function TabsSoft() {
   return (
     <Tabs defaultValue="overview">
       <TabsList variant="soft">
@@ -21,7 +21,7 @@ export function Soft() {
   );
 }
 
-export function Solid() {
+export function TabsSolid() {
   return (
     <Tabs defaultValue="overview">
       <TabsList variant="solid">
@@ -42,4 +42,4 @@ export function Solid() {
   );
 }
 
-export default Soft;
+export default TabsSoft;

--- a/apps/www/docs/previews/textarea/textarea-variant.tsx
+++ b/apps/www/docs/previews/textarea/textarea-variant.tsx
@@ -1,15 +1,15 @@
 import { Textarea } from '@/registry/ui/textarea';
 
-export function Surface() {
+export function TextareaSurface() {
   return <Textarea placeholder="Write something..." />;
 }
 
-export function Outline() {
+export function TextareaOutline() {
   return <Textarea variant="outline" placeholder="Write something..." />;
 }
 
-export function Soft() {
+export function TextareaSoft() {
   return <Textarea variant="soft" placeholder="Write something..." />;
 }
 
-export default Surface;
+export default TextareaSurface;

--- a/apps/www/docs/previews/toggle-group/toggle-group-variants.tsx
+++ b/apps/www/docs/previews/toggle-group/toggle-group-variants.tsx
@@ -18,7 +18,7 @@ export default function ToggleGroupVariants() {
   );
 }
 
-export function Outline() {
+export function ToggleGroupOutline() {
   return (
     <ToggleGroup variant="outline">
       <ToggleGroupItem value="left" aria-label="Align left">
@@ -34,7 +34,7 @@ export function Outline() {
   );
 }
 
-export function Solid() {
+export function ToggleGroupSolid() {
   return (
     <ToggleGroup variant="solid">
       <ToggleGroupItem value="left" aria-label="Align left">

--- a/apps/www/docs/previews/toggle/toggle-variant.tsx
+++ b/apps/www/docs/previews/toggle/toggle-variant.tsx
@@ -4,7 +4,7 @@ import { BoldIcon } from '@heroicons/react/16/solid';
 
 import { Toggle } from '@/registry/ui/toggle';
 
-export function Soft() {
+export function ToggleSoft() {
   return (
     <Toggle aria-label="Toggle bold">
       <BoldIcon />
@@ -12,7 +12,7 @@ export function Soft() {
   );
 }
 
-export function Outline() {
+export function ToggleOutline() {
   return (
     <Toggle variant="outline" aria-label="Toggle bold">
       <BoldIcon />
@@ -20,7 +20,7 @@ export function Outline() {
   );
 }
 
-export function Solid() {
+export function ToggleSolid() {
   return (
     <Toggle variant="solid" aria-label="Toggle bold">
       <BoldIcon />
@@ -28,4 +28,4 @@ export function Solid() {
   );
 }
 
-export default Soft;
+export default ToggleSoft;


### PR DESCRIPTION
Mechanical codemod: bare named exports in apps/www/docs/previews/<comp>/*.tsx now prefixed with the component dir in PascalCase (e.g. Solid -> ButtonSolid). Default exports and registry.ts imports updated to match. Rendered HTML unchanged — baseline snapshot from #155 still passes.