### PR TITLE
feat(www): equivalence test + swap consumer to registry.generated (#158)

### DIFF
--- a/apps/www/docs/components/component-preview.tsx
+++ b/apps/www/docs/components/component-preview.tsx
@@ -1,6 +1,5 @@
 import { highlight } from 'fumadocs-core/highlight';
-import { registry } from '@/docs/previews/registry';
-import { extractExport } from '@/docs/lib/extract-export';
+import { registry } from '@/docs/previews/registry.generated';
 import { CodeBlock } from '@/docs/components/code-block';
 import { CodeCollapsibleWrapper } from '@/docs/components/code-collapsible-wrapper';
 import {
@@ -27,15 +26,13 @@ function normalize(opt: SelectOption): { label: string; value: string } {
 export async function ComponentPreview({ name, select }: ComponentPreviewProps) {
   const entry = registry[name];
 
-  if (select && entry?.variants) {
+  if (select && entry) {
     const options = select.map(normalize);
     const variants = await Promise.all(
       options.map(async (opt) => {
-        const VariantComponent = entry.variants![opt.value];
-        const snippet = extractExport(
-          entry.source,
-          opt.value.charAt(0).toUpperCase() + opt.value.slice(1)
-        );
+        const exportMeta = entry.exports.find((e) => e.value === opt.value);
+        const VariantComponent = exportMeta?.component;
+        const snippet = exportMeta?.snippet ?? '';
         const highlighted = snippet
           ? await highlight(snippet, {
               lang: 'tsx',
@@ -68,7 +65,7 @@ export async function ComponentPreview({ name, select }: ComponentPreviewProps) 
       })
     : null;
 
-  const Preview = entry?.component;
+  const Preview = entry?.defaultExport.component;
 
   return (
     <div className="mt-3 mb-7 rounded-lg border border-line">

--- a/apps/www/docs/previews/registry.generated.ts
+++ b/apps/www/docs/previews/registry.generated.ts
@@ -2103,21 +2103,21 @@ export const registry: Record<string, PreviewEntry> = {
   'toggle-group-variants': {
     slug: 'toggle-group-variants',
     defaultExport: {
-      name: 'ToggleGroupVariants',
-      value: 'variants',
-      label: 'Variants',
-      component: ToggleGroupVariantsModule.default,
+      name: 'ToggleGroupSoft',
+      value: 'soft',
+      label: 'Soft',
+      component: ToggleGroupVariantsModule.ToggleGroupSoft,
       snippet:
-        'export default function ToggleGroupVariants() {\n  return (\n    <ToggleGroup>\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}',
+        'export function ToggleGroupSoft() {\n  return (\n    <ToggleGroup>\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}',
     },
     exports: [
       {
-        name: 'ToggleGroupVariants',
-        value: 'variants',
-        label: 'Variants',
-        component: ToggleGroupVariantsModule.default,
+        name: 'ToggleGroupSoft',
+        value: 'soft',
+        label: 'Soft',
+        component: ToggleGroupVariantsModule.ToggleGroupSoft,
         snippet:
-          'export default function ToggleGroupVariants() {\n  return (\n    <ToggleGroup>\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}',
+          'export function ToggleGroupSoft() {\n  return (\n    <ToggleGroup>\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}',
       },
       {
         name: 'ToggleGroupOutline',
@@ -2137,7 +2137,7 @@ export const registry: Record<string, PreviewEntry> = {
       },
     ],
     source:
-      'import { TextAlignCenterIcon, TextAlignLeftIcon, TextAlignRightIcon } from \'@radix-ui/react-icons\';\n\nimport { ToggleGroup, ToggleGroupItem } from \'@/registry/ui/toggle-group\';\n\nexport default function ToggleGroupVariants() {\n  return (\n    <ToggleGroup>\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}\n\nexport function ToggleGroupOutline() {\n  return (\n    <ToggleGroup variant="outline">\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}\n\nexport function ToggleGroupSolid() {\n  return (\n    <ToggleGroup variant="solid">\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}\n',
+      'import { TextAlignCenterIcon, TextAlignLeftIcon, TextAlignRightIcon } from \'@radix-ui/react-icons\';\n\nimport { ToggleGroup, ToggleGroupItem } from \'@/registry/ui/toggle-group\';\n\nexport function ToggleGroupSoft() {\n  return (\n    <ToggleGroup>\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}\n\nexport default ToggleGroupSoft;\n\nexport function ToggleGroupOutline() {\n  return (\n    <ToggleGroup variant="outline">\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}\n\nexport function ToggleGroupSolid() {\n  return (\n    <ToggleGroup variant="solid">\n      <ToggleGroupItem value="left" aria-label="Align left">\n        <TextAlignLeftIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="center" aria-label="Align center">\n        <TextAlignCenterIcon />\n      </ToggleGroupItem>\n      <ToggleGroupItem value="right" aria-label="Align right">\n        <TextAlignRightIcon />\n      </ToggleGroupItem>\n    </ToggleGroup>\n  );\n}\n',
   },
   'toggle-group-vertical': {
     slug: 'toggle-group-vertical',

--- a/apps/www/docs/previews/registry.legacy.ts
+++ b/apps/www/docs/previews/registry.legacy.ts
@@ -1,0 +1,540 @@
+import type React from 'react';
+import fs from 'fs';
+import path from 'path';
+import AccordionHero from './accordion/accordion-hero';
+import AccordionDefault from './accordion/accordion-default';
+import AccordionMultiple from './accordion/accordion-multiple';
+import AlertDialogHero from './alert-dialog/alert-dialog-hero';
+import AlertDialogDefault from './alert-dialog/alert-dialog-default';
+import AlertDialogWithIcon from './alert-dialog/alert-dialog-with-icon';
+import AvatarHero from './avatar/avatar-hero';
+import AvatarDefault from './avatar/avatar-default';
+import AvatarSizeDefault, {
+  AvatarSm as AvatarSizeSm,
+  AvatarLg as AvatarSizeLg,
+} from './avatar/avatar-size';
+import AvatarWithBadge from './avatar/avatar-with-badge';
+import AvatarGroup from './avatar/avatar-group';
+import CheckboxHero from './checkbox/checkbox-hero';
+import CheckboxDefault from './checkbox/checkbox-default';
+import CheckboxVariantDefault, {
+  CheckboxSolid as CheckboxVariantSolid,
+  CheckboxSurface as CheckboxVariantSurface,
+} from './checkbox/checkbox-variant';
+import CheckboxThemeDefault, {
+  CheckboxGray as CheckboxThemeGray,
+  CheckboxAccent as CheckboxThemeAccent,
+} from './checkbox/checkbox-theme';
+import CheckboxIndeterminate from './checkbox/checkbox-indeterminate';
+import CheckboxGroupHero from './checkbox-group/checkbox-group-hero';
+import CheckboxGroupDefault from './checkbox-group/checkbox-group-default';
+import CheckboxGroupVariantDefault, {
+  CheckboxGroupSolid as CheckboxGroupVariantSolid,
+  CheckboxGroupSurface as CheckboxGroupVariantSurface,
+} from './checkbox-group/checkbox-group-variant';
+import CheckboxGroupThemeDefault, {
+  CheckboxGroupGray as CheckboxGroupThemeGray,
+  CheckboxGroupAccent as CheckboxGroupThemeAccent,
+} from './checkbox-group/checkbox-group-theme';
+import CheckboxGroupParent from './checkbox-group/checkbox-group-parent';
+import CheckboxGroupNested from './checkbox-group/checkbox-group-nested';
+import DialogHero from './dialog/dialog-hero';
+import DialogDefault from './dialog/dialog-default';
+import DialogScrollable from './dialog/dialog-scrollable';
+import FormHero from './form/form-hero';
+import FormProduct from './form/form-product';
+import InputHero from './input/input-hero';
+import InputVariantDefault, {
+  InputOutline as InputVariantOutline,
+  InputSoft as InputVariantSoft,
+} from './input/input-variant';
+import KbdHero from './kbd/kbd-hero';
+import KbdCombination from './kbd/kbd-combination';
+import KbdVariantDefault, {
+  KbdGhost as KbdVariantGhost,
+  KbdSurface as KbdVariantSurface,
+} from './kbd/kbd-variant';
+import RadioGroupHero from './radio-group/radio-group-hero';
+import RadioGroupVariantDefault, {
+  RadioGroupSurface as RadioGroupVariantSurface,
+} from './radio-group/radio-group-variant';
+import SeparatorHero from './separator/separator-hero';
+import SeparatorVertical from './separator/separator-vertical';
+import SeparatorHorizontal from './separator/separator-horizontal';
+import ToggleGroupHero from './toggle-group/toggle-group-hero';
+import ToggleGroupVariantsDefault, {
+  ToggleGroupOutline as ToggleGroupVariantsOutline,
+  ToggleGroupSolid as ToggleGroupVariantsSolid,
+} from './toggle-group/toggle-group-variants';
+import ToggleGroupConnected from './toggle-group/toggle-group-connected';
+import ToggleGroupVertical from './toggle-group/toggle-group-vertical';
+import SwitchHero from './switch/switch-hero';
+import SwitchWithLabel from './switch/switch-with-label';
+import SwitchThemeDefault, {
+  SwitchGray as SwitchThemeGray,
+  SwitchAccent as SwitchThemeAccent,
+} from './switch/switch-theme';
+import TabsHero from './tabs/tabs-hero';
+import TabsVariantsDefault, {
+  TabsSoft as TabsVariantsSoft,
+  TabsSolid as TabsVariantsSolid,
+} from './tabs/tabs-variants';
+import TabsOrientation from './tabs/tabs-orientation';
+import TabsWithSurface from './tabs/tabs-with-surface';
+import TabsTransition from './tabs/tabs-transition';
+
+// @scaffold:imports
+import DropdownMenuHero from './dropdown-menu/dropdown-menu-hero';
+import DropdownMenuBasic from './dropdown-menu/dropdown-menu-basic';
+import DropdownMenuVariantDefault, {
+  DropdownMenuSoft as DropdownMenuVariantSoft,
+  DropdownMenuSolid as DropdownMenuVariantSolid,
+} from './dropdown-menu/dropdown-menu-variant';
+import DropdownMenuThemeDefault, {
+  DropdownMenuGray as DropdownMenuThemeGray,
+  DropdownMenuAccent as DropdownMenuThemeAccent,
+} from './dropdown-menu/dropdown-menu-theme';
+import ButtonHero from './button/button-hero';
+import ButtonVariantsDefault, {
+  ButtonSolid as ButtonVariantsSolid,
+  ButtonOutline as ButtonVariantsOutline,
+  ButtonSurface as ButtonVariantsSurface,
+  ButtonSoft as ButtonVariantsSoft,
+  ButtonGhost as ButtonVariantsGhost,
+} from './button/button-variants';
+import ButtonThemeDefault, {
+  ButtonGray as ButtonThemeGray,
+  ButtonAccent as ButtonThemeAccent,
+  ButtonDestructive as ButtonThemeDestructive,
+} from './button/button-theme';
+import ButtonWithIconDefault, {
+  ButtonLeading as ButtonWithIconLeading,
+  ButtonTrailing as ButtonWithIconTrailing,
+} from './button/button-with-icon';
+import ButtonIconButton from './button/button-icon-button';
+import ButtonGroupHero from './button-group/button-group-hero';
+import ButtonGroupDefault from './button-group/button-group-default';
+import ButtonGroupVertical from './button-group/button-group-vertical';
+import ButtonGroupWithIcons from './button-group/button-group-with-icons';
+import ButtonGroupIconButtons from './button-group/button-group-icon-buttons';
+import ButtonGroupWithSeparator from './button-group/button-group-with-separator';
+import ButtonGroupWithText from './button-group/button-group-with-text';
+import BadgeHero from './badge/badge-hero';
+import BadgeVariantsDefault, {
+  BadgeSolid as BadgeVariantsSolid,
+  BadgeOutline as BadgeVariantsOutline,
+  BadgeSurface as BadgeVariantsSurface,
+  BadgeSoft as BadgeVariantsSoft,
+} from './badge/badge-variants';
+import BadgeThemeDefault, {
+  BadgeGray as BadgeThemeGray,
+  BadgeAccent as BadgeThemeAccent,
+  BadgeDestructive as BadgeThemeDestructive,
+  BadgeWarning as BadgeThemeWarning,
+  BadgeSuccess as BadgeThemeSuccess,
+} from './badge/badge-theme';
+import BadgeWithIconDefault, {
+  BadgeLeading as BadgeWithIconLeading,
+  BadgeTrailing as BadgeWithIconTrailing,
+} from './badge/badge-with-icon';
+import BadgeIconOnly from './badge/badge-icon-only';
+import BadgeAsLink from './badge/badge-as-link';
+import ToggleHero from './toggle/toggle-hero';
+import ToggleVariantDefault, {
+  ToggleOutline as ToggleVariantOutline,
+  ToggleSolid as ToggleVariantSolid,
+} from './toggle/toggle-variant';
+import TextareaHero from './textarea/textarea-hero';
+import TextareaVariantDefault, {
+  TextareaOutline as TextareaVariantOutline,
+  TextareaSoft as TextareaVariantSoft,
+} from './textarea/textarea-variant';
+import TextareaManualResize from './textarea/textarea-manual-resize';
+import TextareaWithLabel from './textarea/textarea-with-label';
+import TextareaWithButton from './textarea/textarea-with-button';
+
+const previewsDir = path.join(process.cwd(), 'docs/previews');
+
+function readSource(subpath: string): string {
+  return fs.readFileSync(path.join(previewsDir, subpath), 'utf-8');
+}
+
+interface RegistryEntry {
+  component: React.ComponentType;
+  variants?: Record<string, React.ComponentType>;
+  source: string;
+}
+
+export const registry: Record<string, RegistryEntry> = {
+  'accordion-hero': {
+    component: AccordionHero,
+    source: readSource('accordion/accordion-hero.tsx'),
+  },
+  'accordion-default': {
+    component: AccordionDefault,
+    source: readSource('accordion/accordion-default.tsx'),
+  },
+  'accordion-multiple': {
+    component: AccordionMultiple,
+    source: readSource('accordion/accordion-multiple.tsx'),
+  },
+  'alert-dialog-hero': {
+    component: AlertDialogHero,
+    source: readSource('alert-dialog/alert-dialog-hero.tsx'),
+  },
+  'alert-dialog-default': {
+    component: AlertDialogDefault,
+    source: readSource('alert-dialog/alert-dialog-default.tsx'),
+  },
+  'alert-dialog-with-icon': {
+    component: AlertDialogWithIcon,
+    source: readSource('alert-dialog/alert-dialog-with-icon.tsx'),
+  },
+  'avatar-hero': {
+    component: AvatarHero,
+    source: readSource('avatar/avatar-hero.tsx'),
+  },
+  'avatar-default': {
+    component: AvatarDefault,
+    source: readSource('avatar/avatar-default.tsx'),
+  },
+  'avatar-size': {
+    component: AvatarSizeDefault,
+    variants: { default: AvatarSizeDefault, sm: AvatarSizeSm, lg: AvatarSizeLg },
+    source: readSource('avatar/avatar-size.tsx'),
+  },
+  'avatar-with-badge': {
+    component: AvatarWithBadge,
+    source: readSource('avatar/avatar-with-badge.tsx'),
+  },
+  'avatar-group': {
+    component: AvatarGroup,
+    source: readSource('avatar/avatar-group.tsx'),
+  },
+  'checkbox-hero': {
+    component: CheckboxHero,
+    source: readSource('checkbox/checkbox-hero.tsx'),
+  },
+  'checkbox-default': {
+    component: CheckboxDefault,
+    source: readSource('checkbox/checkbox-default.tsx'),
+  },
+  'checkbox-variant': {
+    component: CheckboxVariantDefault,
+    variants: { solid: CheckboxVariantSolid, surface: CheckboxVariantSurface },
+    source: readSource('checkbox/checkbox-variant.tsx'),
+  },
+  'checkbox-theme': {
+    component: CheckboxThemeDefault,
+    variants: { gray: CheckboxThemeGray, accent: CheckboxThemeAccent },
+    source: readSource('checkbox/checkbox-theme.tsx'),
+  },
+  'checkbox-indeterminate': {
+    component: CheckboxIndeterminate,
+    source: readSource('checkbox/checkbox-indeterminate.tsx'),
+  },
+  'checkbox-group-hero': {
+    component: CheckboxGroupHero,
+    source: readSource('checkbox-group/checkbox-group-hero.tsx'),
+  },
+  'checkbox-group-default': {
+    component: CheckboxGroupDefault,
+    source: readSource('checkbox-group/checkbox-group-default.tsx'),
+  },
+  'checkbox-group-variant': {
+    component: CheckboxGroupVariantDefault,
+    variants: { solid: CheckboxGroupVariantSolid, surface: CheckboxGroupVariantSurface },
+    source: readSource('checkbox-group/checkbox-group-variant.tsx'),
+  },
+  'checkbox-group-theme': {
+    component: CheckboxGroupThemeDefault,
+    variants: { gray: CheckboxGroupThemeGray, accent: CheckboxGroupThemeAccent },
+    source: readSource('checkbox-group/checkbox-group-theme.tsx'),
+  },
+  'checkbox-group-parent': {
+    component: CheckboxGroupParent,
+    source: readSource('checkbox-group/checkbox-group-parent.tsx'),
+  },
+  'checkbox-group-nested': {
+    component: CheckboxGroupNested,
+    source: readSource('checkbox-group/checkbox-group-nested.tsx'),
+  },
+  'dialog-hero': {
+    component: DialogHero,
+    source: readSource('dialog/dialog-hero.tsx'),
+  },
+  'dialog-default': {
+    component: DialogDefault,
+    source: readSource('dialog/dialog-default.tsx'),
+  },
+  'dialog-scrollable': {
+    component: DialogScrollable,
+    source: readSource('dialog/dialog-scrollable.tsx'),
+  },
+  'form-hero': {
+    component: FormHero,
+    source: readSource('form/form-hero.tsx'),
+  },
+  'form-product': {
+    component: FormProduct,
+    source: readSource('form/form-product.tsx'),
+  },
+  'input-hero': {
+    component: InputHero,
+    source: readSource('input/input-hero.tsx'),
+  },
+  'input-variant': {
+    component: InputVariantDefault,
+    variants: {
+      surface: InputVariantDefault,
+      outline: InputVariantOutline,
+      soft: InputVariantSoft,
+    },
+    source: readSource('input/input-variant.tsx'),
+  },
+  'kbd-hero': {
+    component: KbdHero,
+    source: readSource('kbd/kbd-hero.tsx'),
+  },
+  'kbd-combination': {
+    component: KbdCombination,
+    source: readSource('kbd/kbd-combination.tsx'),
+  },
+  'kbd-variant': {
+    component: KbdVariantDefault,
+    variants: { soft: KbdVariantDefault, surface: KbdVariantSurface, ghost: KbdVariantGhost },
+    source: readSource('kbd/kbd-variant.tsx'),
+  },
+  'radio-group-hero': {
+    component: RadioGroupHero,
+    source: readSource('radio-group/radio-group-hero.tsx'),
+  },
+  'radio-group-variant': {
+    component: RadioGroupVariantDefault,
+    variants: { solid: RadioGroupVariantDefault, surface: RadioGroupVariantSurface },
+    source: readSource('radio-group/radio-group-variant.tsx'),
+  },
+  'separator-hero': {
+    component: SeparatorHero,
+    source: readSource('separator/separator-hero.tsx'),
+  },
+  'separator-vertical': {
+    component: SeparatorVertical,
+    source: readSource('separator/separator-vertical.tsx'),
+  },
+  'separator-horizontal': {
+    component: SeparatorHorizontal,
+    source: readSource('separator/separator-horizontal.tsx'),
+  },
+  'toggle-group-hero': {
+    component: ToggleGroupHero,
+    source: readSource('toggle-group/toggle-group-hero.tsx'),
+  },
+  'toggle-group-variants': {
+    component: ToggleGroupVariantsDefault,
+    variants: {
+      soft: ToggleGroupVariantsDefault,
+      outline: ToggleGroupVariantsOutline,
+      solid: ToggleGroupVariantsSolid,
+    },
+    source: readSource('toggle-group/toggle-group-variants.tsx'),
+  },
+  'toggle-group-connected': {
+    component: ToggleGroupConnected,
+    source: readSource('toggle-group/toggle-group-connected.tsx'),
+  },
+  'toggle-group-vertical': {
+    component: ToggleGroupVertical,
+    source: readSource('toggle-group/toggle-group-vertical.tsx'),
+  },
+  'switch-hero': {
+    component: SwitchHero,
+    source: readSource('switch/switch-hero.tsx'),
+  },
+  'switch-with-label': {
+    component: SwitchWithLabel,
+    source: readSource('switch/switch-with-label.tsx'),
+  },
+  'switch-theme': {
+    component: SwitchThemeDefault,
+    variants: {
+      gray: SwitchThemeGray,
+      accent: SwitchThemeAccent,
+    },
+    source: readSource('switch/switch-theme.tsx'),
+  },
+  'tabs-hero': {
+    component: TabsHero,
+    source: readSource('tabs/tabs-hero.tsx'),
+  },
+  'tabs-variants': {
+    component: TabsVariantsDefault,
+    variants: { soft: TabsVariantsSoft, solid: TabsVariantsSolid },
+    source: readSource('tabs/tabs-variants.tsx'),
+  },
+  'tabs-orientation': {
+    component: TabsOrientation,
+    source: readSource('tabs/tabs-orientation.tsx'),
+  },
+  'tabs-with-surface': {
+    component: TabsWithSurface,
+    source: readSource('tabs/tabs-with-surface.tsx'),
+  },
+  'tabs-transition': {
+    component: TabsTransition,
+    source: readSource('tabs/tabs-transition.tsx'),
+  },
+  // @scaffold:entries
+  'dropdown-menu-hero': {
+    component: DropdownMenuHero,
+    source: readSource('dropdown-menu/dropdown-menu-hero.tsx'),
+  },
+  'dropdown-menu-basic': {
+    component: DropdownMenuBasic,
+    source: readSource('dropdown-menu/dropdown-menu-basic.tsx'),
+  },
+  'dropdown-menu-variant': {
+    component: DropdownMenuVariantDefault,
+    variants: { soft: DropdownMenuVariantSoft, solid: DropdownMenuVariantSolid },
+    source: readSource('dropdown-menu/dropdown-menu-variant.tsx'),
+  },
+  'dropdown-menu-theme': {
+    component: DropdownMenuThemeDefault,
+    variants: { gray: DropdownMenuThemeGray, accent: DropdownMenuThemeAccent },
+    source: readSource('dropdown-menu/dropdown-menu-theme.tsx'),
+  },
+  'button-hero': {
+    component: ButtonHero,
+    source: readSource('button/button-hero.tsx'),
+  },
+  'button-variants': {
+    component: ButtonVariantsDefault,
+    variants: {
+      solid: ButtonVariantsSolid,
+      outline: ButtonVariantsOutline,
+      surface: ButtonVariantsSurface,
+      soft: ButtonVariantsSoft,
+      ghost: ButtonVariantsGhost,
+    },
+    source: readSource('button/button-variants.tsx'),
+  },
+  'button-theme': {
+    component: ButtonThemeDefault,
+    variants: {
+      gray: ButtonThemeGray,
+      accent: ButtonThemeAccent,
+      destructive: ButtonThemeDestructive,
+    },
+    source: readSource('button/button-theme.tsx'),
+  },
+  'button-with-icon': {
+    component: ButtonWithIconDefault,
+    variants: {
+      leading: ButtonWithIconLeading,
+      trailing: ButtonWithIconTrailing,
+    },
+    source: readSource('button/button-with-icon.tsx'),
+  },
+  'button-icon-button': {
+    component: ButtonIconButton,
+    source: readSource('button/button-icon-button.tsx'),
+  },
+  'button-group-hero': {
+    component: ButtonGroupHero,
+    source: readSource('button-group/button-group-hero.tsx'),
+  },
+  'button-group-default': {
+    component: ButtonGroupDefault,
+    source: readSource('button-group/button-group-default.tsx'),
+  },
+  'button-group-vertical': {
+    component: ButtonGroupVertical,
+    source: readSource('button-group/button-group-vertical.tsx'),
+  },
+  'button-group-with-icons': {
+    component: ButtonGroupWithIcons,
+    source: readSource('button-group/button-group-with-icons.tsx'),
+  },
+  'button-group-icon-buttons': {
+    component: ButtonGroupIconButtons,
+    source: readSource('button-group/button-group-icon-buttons.tsx'),
+  },
+  'button-group-with-separator': {
+    component: ButtonGroupWithSeparator,
+    source: readSource('button-group/button-group-with-separator.tsx'),
+  },
+  'button-group-with-text': {
+    component: ButtonGroupWithText,
+    source: readSource('button-group/button-group-with-text.tsx'),
+  },
+  'badge-hero': { component: BadgeHero, source: readSource('badge/badge-hero.tsx') },
+  'badge-variants': {
+    component: BadgeVariantsDefault,
+    variants: {
+      solid: BadgeVariantsSolid,
+      outline: BadgeVariantsOutline,
+      surface: BadgeVariantsSurface,
+      soft: BadgeVariantsSoft,
+    },
+    source: readSource('badge/badge-variants.tsx'),
+  },
+  'badge-theme': {
+    component: BadgeThemeDefault,
+    variants: {
+      gray: BadgeThemeGray,
+      accent: BadgeThemeAccent,
+      destructive: BadgeThemeDestructive,
+      warning: BadgeThemeWarning,
+      success: BadgeThemeSuccess,
+    },
+    source: readSource('badge/badge-theme.tsx'),
+  },
+  'badge-with-icon': {
+    component: BadgeWithIconDefault,
+    variants: {
+      leading: BadgeWithIconLeading,
+      trailing: BadgeWithIconTrailing,
+    },
+    source: readSource('badge/badge-with-icon.tsx'),
+  },
+  'badge-icon-only': { component: BadgeIconOnly, source: readSource('badge/badge-icon-only.tsx') },
+  'badge-as-link': { component: BadgeAsLink, source: readSource('badge/badge-as-link.tsx') },
+  'toggle-hero': {
+    component: ToggleHero,
+    source: readSource('toggle/toggle-hero.tsx'),
+  },
+  'toggle-variant': {
+    component: ToggleVariantDefault,
+    variants: {
+      soft: ToggleVariantDefault,
+      outline: ToggleVariantOutline,
+      solid: ToggleVariantSolid,
+    },
+    source: readSource('toggle/toggle-variant.tsx'),
+  },
+  'textarea-hero': {
+    component: TextareaHero,
+    source: readSource('textarea/textarea-hero.tsx'),
+  },
+  'textarea-variant': {
+    component: TextareaVariantDefault,
+    variants: {
+      surface: TextareaVariantDefault,
+      outline: TextareaVariantOutline,
+      soft: TextareaVariantSoft,
+    },
+    source: readSource('textarea/textarea-variant.tsx'),
+  },
+  'textarea-manual-resize': {
+    component: TextareaManualResize,
+    source: readSource('textarea/textarea-manual-resize.tsx'),
+  },
+  'textarea-with-label': {
+    component: TextareaWithLabel,
+    source: readSource('textarea/textarea-with-label.tsx'),
+  },
+  'textarea-with-button': {
+    component: TextareaWithButton,
+    source: readSource('textarea/textarea-with-button.tsx'),
+  },
+};

--- a/apps/www/docs/previews/toggle-group/toggle-group-variants.tsx
+++ b/apps/www/docs/previews/toggle-group/toggle-group-variants.tsx
@@ -2,7 +2,7 @@ import { TextAlignCenterIcon, TextAlignLeftIcon, TextAlignRightIcon } from '@rad
 
 import { ToggleGroup, ToggleGroupItem } from '@/registry/ui/toggle-group';
 
-export default function ToggleGroupVariants() {
+export function ToggleGroupSoft() {
   return (
     <ToggleGroup>
       <ToggleGroupItem value="left" aria-label="Align left">
@@ -17,6 +17,8 @@ export default function ToggleGroupVariants() {
     </ToggleGroup>
   );
 }
+
+export default ToggleGroupSoft;
 
 export function ToggleGroupOutline() {
   return (

--- a/apps/www/scripts/registry-equivalence.test.ts
+++ b/apps/www/scripts/registry-equivalence.test.ts
@@ -1,0 +1,44 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { registry as generated } from '../docs/previews/registry.generated';
+import { registry as legacy } from '../docs/previews/registry.legacy';
+
+describe('registry equivalence', () => {
+  it('identical slug sets', () => {
+    expect(Object.keys(generated).sort()).toEqual(Object.keys(legacy).sort());
+  });
+
+  it('identical variant value sets per entry', () => {
+    for (const [slug, legacyEntry] of Object.entries(legacy)) {
+      const genEntry = generated[slug];
+      const legacyVariantKeys = Object.keys(legacyEntry.variants ?? {}).sort();
+      const genExportValues = genEntry.exports.map((e) => e.value).sort();
+
+      if (legacyVariantKeys.length > 0) {
+        expect(genExportValues, `${slug}: variant values`).toEqual(legacyVariantKeys);
+      } else {
+        expect(genEntry.exports, `${slug}: single-export entry`).toHaveLength(1);
+      }
+    }
+  });
+
+  it('identical rendered HTML for each component ref', () => {
+    for (const [slug, legacyEntry] of Object.entries(legacy)) {
+      const genEntry = generated[slug];
+
+      const legacyHtml = renderToString(createElement(legacyEntry.component));
+      const genHtml = renderToString(createElement(genEntry.defaultExport.component));
+      expect(genHtml, `${slug}: default component`).toBe(legacyHtml);
+
+      if (legacyEntry.variants) {
+        for (const [variantKey, VariantComp] of Object.entries(legacyEntry.variants)) {
+          const genExport = genEntry.exports.find((e) => e.value === variantKey);
+          const legacyVariantHtml = renderToString(createElement(VariantComp));
+          const genVariantHtml = renderToString(createElement(genExport!.component));
+          expect(genVariantHtml, `${slug} :: ${variantKey}`).toBe(legacyVariantHtml);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
- Copy registry.ts → registry.legacy.ts for migration comparison
- Add registry-equivalence.test.ts: slug sets, variant value sets, rendered HTML per component ref
- Rename ToggleGroupVariants → ToggleGroupSoft so generator emits key 'soft' matching legacy; regenerate registry.generated.ts
- Swap component-preview.tsx to registry.generated; use defaultExport.component, exports.find, inline snippet