### PR TITLE
refactor(www): rewrite ComponentPreview — single render path, select …

### DIFF
--- a/apps/www/docs/components/component-preview-client.tsx
+++ b/apps/www/docs/components/component-preview-client.tsx
@@ -21,20 +21,18 @@ export interface VariantItem {
 
 export function ComponentPreviewClient({
   name,
-  preview,
   variants,
 }: {
   name: string;
-  preview?: React.ReactNode;
-  variants?: VariantItem[];
+  variants: VariantItem[];
 }) {
-  const [activeValue, setActiveValue] = React.useState(variants?.[0]?.value ?? '');
-  const activeVariant = variants?.find((v) => v.value === activeValue) ?? variants?.[0];
+  const [activeValue, setActiveValue] = React.useState(variants[0]?.value ?? '');
+  const activeVariant = variants.find((v) => v.value === activeValue) ?? variants[0];
 
   return (
     <>
       <div className="relative flex min-h-50 items-center justify-center p-6">
-        {variants && (
+        {variants.length > 1 && (
           <select
             className="absolute top-3 right-3 cursor-pointer rounded-md border border-line bg-surface px-2 py-1 text-sm text-secondary"
             value={activeValue}
@@ -47,13 +45,11 @@ export function ComponentPreviewClient({
             ))}
           </select>
         )}
-        {variants
-          ? (activeVariant?.rendered ?? (
-              <p className="text-sm text-secondary">Preview not found: {name}</p>
-            ))
-          : (preview ?? <p className="text-sm text-secondary">Preview not found: {name}</p>)}
+        {activeVariant?.rendered ?? (
+          <p className="text-sm text-secondary">Preview not found: {name}</p>
+        )}
       </div>
-      {variants && activeVariant?.highlighted && (
+      {activeVariant?.highlighted && (
         <div className="border-t border-line">
           <CodeCollapsibleWrapper
             lineCount={activeVariant.lineCount}

--- a/apps/www/docs/components/component-preview.test.tsx
+++ b/apps/www/docs/components/component-preview.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderToString } from 'react-dom/server';
+
+vi.mock('@/docs/previews/registry.generated', () => ({
+  registry: {
+    'button-variants': {
+      slug: 'button-variants',
+      defaultExport: {
+        name: 'ButtonSolid',
+        value: 'solid',
+        label: 'Solid',
+        component: () => React.createElement('div', null, 'Solid button'),
+        snippet: 'export function ButtonSolid() { return <Button variant="solid" />; }',
+      },
+      exports: [
+        {
+          name: 'ButtonSolid',
+          value: 'solid',
+          label: 'Solid',
+          component: () => React.createElement('div', null, 'Solid button'),
+          snippet: 'export function ButtonSolid() { return <Button variant="solid" />; }',
+        },
+        {
+          name: 'ButtonOutline',
+          value: 'outline',
+          label: 'Outline',
+          component: () => React.createElement('div', null, 'Outline button'),
+          snippet: 'export function ButtonOutline() { return <Button variant="outline" />; }',
+        },
+      ],
+      source: '// full source',
+    },
+  },
+}));
+
+vi.mock('fumadocs-core/highlight', () => ({
+  highlight: vi.fn().mockResolvedValue(React.createElement('span', null, 'highlighted')),
+}));
+
+let capturedProps: Record<string, unknown> = {};
+vi.mock('./component-preview-client', () => ({
+  ComponentPreviewClient: (props: Record<string, unknown>) => {
+    capturedProps = props;
+    return React.createElement('div', null, 'mock-client');
+  },
+}));
+
+const { ComponentPreview } = await import('./component-preview');
+
+describe('ComponentPreview D-tests (#159)', () => {
+  beforeEach(() => {
+    capturedProps = {};
+  });
+
+  it('implicit (no select) renders all exports in declaration order', async () => {
+    const el = await ComponentPreview({ name: 'button-variants' });
+    renderToString(el as React.ReactElement);
+    const variants = capturedProps.variants as Array<{ value: string }>;
+    expect(variants).toHaveLength(2);
+    expect(variants[0].value).toBe('solid');
+    expect(variants[1].value).toBe('outline');
+  });
+
+  it('explicit select={["solid"]} renders only that variant', async () => {
+    const el = await ComponentPreview({ name: 'button-variants', select: ['solid'] });
+    renderToString(el as React.ReactElement);
+    const variants = capturedProps.variants as Array<{ value: string }>;
+    expect(variants).toHaveLength(1);
+    expect(variants[0].value).toBe('solid');
+  });
+
+  it('relabelled select={[{ value: "solid", label: "Primary" }]} shows custom label', async () => {
+    const el = await ComponentPreview({
+      name: 'button-variants',
+      select: [{ value: 'solid', label: 'Primary' }],
+    });
+    renderToString(el as React.ReactElement);
+    const variants = capturedProps.variants as Array<{ value: string; label: string }>;
+    expect(variants).toHaveLength(1);
+    expect(variants[0].label).toBe('Primary');
+  });
+});

--- a/apps/www/docs/components/component-preview.tsx
+++ b/apps/www/docs/components/component-preview.tsx
@@ -1,13 +1,5 @@
 import { highlight } from 'fumadocs-core/highlight';
 import { registry } from '@/docs/previews/registry.generated';
-import { CodeBlock } from '@/docs/components/code-block';
-import { CodeCollapsibleWrapper } from '@/docs/components/code-collapsible-wrapper';
-import {
-  CodeBlockCommandBar,
-  CodeBlockExpandButton,
-  CodeBlockCopyButton,
-} from '@/docs/components/code-block-command-bar';
-import { Separator } from '@/registry/ui/separator';
 import { ComponentPreviewClient } from './component-preview-client';
 
 type SelectOption = string | { label: string; value: string };
@@ -26,66 +18,40 @@ function normalize(opt: SelectOption): { label: string; value: string } {
 export async function ComponentPreview({ name, select }: ComponentPreviewProps) {
   const entry = registry[name];
 
-  if (select && entry) {
-    const options = select.map(normalize);
-    const variants = await Promise.all(
-      options.map(async (opt) => {
-        const exportMeta = entry.exports.find((e) => e.value === opt.value);
-        const VariantComponent = exportMeta?.component;
-        const snippet = exportMeta?.snippet ?? '';
-        const highlighted = snippet
-          ? await highlight(snippet, {
-              lang: 'tsx',
-              themes: { light: 'github-light-default', dark: 'github-dark' },
-            })
-          : null;
-        return {
-          ...opt,
-          rendered: VariantComponent ? <VariantComponent key={opt.value} /> : null,
-          highlighted,
-          source: snippet,
-          lineCount: snippet.split('\n').length,
-        };
-      })
-    );
+  const selectedExports = select
+    ? select
+        .map(normalize)
+        .map((opt) => {
+          const exportMeta = entry?.exports.find((e) => e.value === opt.value);
+          return exportMeta ? { ...exportMeta, label: opt.label } : null;
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null)
+    : (entry?.exports ?? []);
 
-    return (
-      <div className="mt-3 mb-7 rounded-lg border border-line">
-        <ComponentPreviewClient name={name} variants={variants} />
-      </div>
-    );
-  }
-
-  const source = entry?.source ?? null;
-  const lineCount = source ? source.split('\n').length : 0;
-  const highlighted = source
-    ? await highlight(source, {
-        lang: 'tsx',
-        themes: { light: 'github-light-default', dark: 'github-dark' },
-      })
-    : null;
-
-  const Preview = entry?.defaultExport.component;
+  const variants = await Promise.all(
+    selectedExports.map(async (exportMeta) => {
+      const VariantComponent = exportMeta.component;
+      const snippet = exportMeta.snippet ?? '';
+      const highlighted = snippet
+        ? await highlight(snippet, {
+            lang: 'tsx',
+            themes: { light: 'github-light-default', dark: 'github-dark' },
+          })
+        : null;
+      return {
+        label: exportMeta.label,
+        value: exportMeta.value,
+        rendered: VariantComponent ? <VariantComponent key={exportMeta.value} /> : null,
+        highlighted,
+        source: snippet,
+        lineCount: snippet.split('\n').length,
+      };
+    })
+  );
 
   return (
     <div className="mt-3 mb-7 rounded-lg border border-line">
-      <ComponentPreviewClient name={name} preview={Preview ? <Preview /> : undefined} />
-      {highlighted && (
-        <div className="border-t border-line">
-          <CodeCollapsibleWrapper
-            lineCount={lineCount}
-            commandBar={
-              <CodeBlockCommandBar>
-                <CodeBlockExpandButton />
-                <Separator orientation="vertical" />
-                <CodeBlockCopyButton code={source!} />
-              </CodeBlockCommandBar>
-            }
-          >
-            <CodeBlock>{highlighted}</CodeBlock>
-          </CodeCollapsibleWrapper>
-        </div>
-      )}
+      <ComponentPreviewClient name={name} variants={variants} />
     </div>
   );
 }


### PR DESCRIPTION
…optional, snippet from export

- select is now optional; absent renders all entry.exports in declaration order
- single render path via entry.exports for both implicit and explicit select
- snippets read from export.snippet directly, no runtime parsing
- client suppresses dropdown when only one variant
- D-tests cover implicit, explicit select, and relabelled select cases