### PR TITLE
agent:chore(gen-registry): fix inaccurate counter-examples in comments

### DIFF
--- a/apps/www/scripts/gen-registry.ts
+++ b/apps/www/scripts/gen-registry.ts
@@ -39,7 +39,7 @@ function dirToPascal(dirName: string): string {
     .join('');
 }
 
-// Second clause handles acronym boundaries: URLParser → url-parser (not ur-lparser)
+// Second clause handles acronym boundaries: URLParser → url-parser (not urlparser)
 function pascalToKebab(pascal: string): string {
   return pascal
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
@@ -47,7 +47,7 @@ function pascalToKebab(pascal: string): string {
     .toLowerCase();
 }
 
-// Second clause handles acronym boundaries: URLParser → URL Parser (not U RLParser)
+// Second clause handles acronym boundaries: URLParser → URL Parser (not URLParser)
 function splitPascal(pascal: string): string {
   return pascal.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
 }

--- a/apps/www/scripts/gen-registry.ts
+++ b/apps/www/scripts/gen-registry.ts
@@ -39,6 +39,7 @@ function dirToPascal(dirName: string): string {
     .join('');
 }
 
+// Second clause handles acronym boundaries: URLParser → url-parser (not ur-lparser)
 function pascalToKebab(pascal: string): string {
   return pascal
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
@@ -46,6 +47,7 @@ function pascalToKebab(pascal: string): string {
     .toLowerCase();
 }
 
+// Second clause handles acronym boundaries: URLParser → URL Parser (not U RLParser)
 function splitPascal(pascal: string): string {
   return pascal.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
 }
@@ -59,6 +61,11 @@ interface NamedFn {
   defaultOnly: boolean;
 }
 
+/**
+ * Handles two default-export shapes:
+ * - `export default function X() {}` — populates defaultName from the fn declaration
+ * - `export default X` (assignment, X is a separately-declared exported fn) — populates defaultName from the identifier
+ */
 function collectExports(sourceFile: ts.SourceFile): {
   named: NamedFn[];
   defaultName: string | null;
@@ -92,6 +99,13 @@ function collectExports(sourceFile: ts.SourceFile): {
   return { named, defaultName };
 }
 
+/**
+ * Enforces three invariants:
+ * 1. At least one named export starting with `<DirPascal>` prefix
+ * 2. A default export must exist
+ * 3. The default export must resolve to one of the named exports
+ * Each invariant throws on violation.
+ */
 export function parsePreviewFile(filePath: string): PreviewEntry {
   const source = fs.readFileSync(filePath, 'utf-8');
   const fileName = path.basename(filePath);


### PR DESCRIPTION
Added targeted comments to four functions in `apps/www/scripts/gen-registry.ts` — no behaviour change:

- `collectExports` (line 69): JSDoc explaining the two default-export shapes it handles (`export default function X() {}` vs `export default X` assignment), so readers don't need to derive this from the AST branches.
- `pascalToKebab` (line 42): one-liner noting the second regex clause handles acronym boundaries (`URLParser` → `url-parser`, not `ur-lparser`).
- `splitPascal` (line 49): mirror one-liner for the same pattern (`URLParser` → `URL Parser`, not `U RLParser`).
- `parsePreviewFile` (line 95): JSDoc listing the three enforced invariants (named export prefix, default export exists, default resolves to a named export) — each throws on violation with a descriptive message.

All gates green: no TypeScript errors in the file, ESLint clean. The unit test suite cannot run in this environment due to a missing native binding (`rolldown`), but this is a pre-existing infrastructure issue unrelated to the changes.

Closes #170