### PR TITLE
agent:refactor(scripts/gen-registry): consolidate duplicate kebab-to-pascal helpers

### DIFF
--- a/apps/www/scripts/gen-registry.ts
+++ b/apps/www/scripts/gen-registry.ts
@@ -32,8 +32,9 @@ export class NamingViolationError extends Error {
   }
 }
 
-function dirToPascal(dirName: string): string {
-  return dirName
+/** Converts a kebab-case string to PascalCase, e.g. "button-group" → "ButtonGroup". */
+function kebabToPascal(str: string): string {
+  return str
     .split('-')
     .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
     .join('');
@@ -116,7 +117,7 @@ export function parsePreviewFile(filePath: string): PreviewEntry {
   const fileName = path.basename(filePath);
   const slug = fileName.replace(/\.tsx?$/, '');
   const dirName = path.basename(path.dirname(filePath));
-  const dirPascal = dirToPascal(dirName);
+  const dirPascal = kebabToPascal(dirName);
 
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -171,13 +172,6 @@ interface ParsedPreview extends PreviewEntry {
   componentDir: string;
 }
 
-function slugToPascal(slug: string): string {
-  return slug
-    .split('-')
-    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-    .join('');
-}
-
 export function parsePreviewsDir(previewsDir: string): ParsedPreview[] {
   const entries: ParsedPreview[] = [];
   const subdirs = fs
@@ -212,7 +206,7 @@ export function renderRegistryModule(entries: ParsedPreview[]): string {
   }
 
   for (const entry of entries) {
-    const moduleAlias = `${slugToPascal(entry.slug)}Module`;
+    const moduleAlias = `${kebabToPascal(entry.slug)}Module`;
     importLines.push(`import * as ${moduleAlias} from './${entry.componentDir}/${entry.slug}';`);
 
     const exportLines = entry.exports.map((e) => {

--- a/apps/www/scripts/gen-registry.ts
+++ b/apps/www/scripts/gen-registry.ts
@@ -39,6 +39,7 @@ function dirToPascal(dirName: string): string {
     .join('');
 }
 
+/** Converts PascalCase to kebab-case, e.g. "URLParser" → "url-parser". */
 function pascalToKebab(pascal: string): string {
   return pascal
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
@@ -46,6 +47,7 @@ function pascalToKebab(pascal: string): string {
     .toLowerCase();
 }
 
+/** Splits PascalCase at word boundaries, e.g. "URLParser" → "URL Parser". */
 function splitPascal(pascal: string): string {
   return pascal.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
 }
@@ -59,6 +61,15 @@ interface NamedFn {
   defaultOnly: boolean;
 }
 
+/**
+ * Parses all exported functions from a TypeScript source file.
+ *
+ * Handles two default-export shapes:
+ * - `export default function X() {}`
+ * - `export default X` (assignment, where `X` is a separately-declared exported fn)
+ *
+ * Both populate `defaultName` with the declared function name.
+ */
 function collectExports(sourceFile: ts.SourceFile): {
   named: NamedFn[];
   defaultName: string | null;
@@ -92,6 +103,14 @@ function collectExports(sourceFile: ts.SourceFile): {
   return { named, defaultName };
 }
 
+/**
+ * Parses a single preview file and validates structural invariants:
+ * - At least one named export starting with `<DirPascal>` prefix
+ * - A default export exists
+ * - The default export resolves to one of the named exports
+ *
+ * Throws if any invariant is violated.
+ */
 export function parsePreviewFile(filePath: string): PreviewEntry {
   const source = fs.readFileSync(filePath, 'utf-8');
   const fileName = path.basename(filePath);


### PR DESCRIPTION
Added JSDoc comments to four functions in `apps/www/scripts/gen-registry.ts` that had non-obvious intent:

- `collectExports` — JSDoc documenting the two supported default-export shapes (`export default function X()` vs `export default X`)
- `pascalToKebab` and `splitPascal` — one-liner comments explaining each function's purpose
- `parsePreviewFile` — JSDoc listing the three enforced invariants (named export prefix, default export exists, default resolves to named export)

No behaviour change. `pnpm prettier` and `pnpm typecheck` (targeting the script directly) both pass.

Closes #170