### PR TITLE
fix(ci): handle comma-list issue refs and set GH_REPO in workflows

### DIFF
--- a/.github/workflows/close-on-develop-merge.yml
+++ b/.github/workflows/close-on-develop-merge.yml
@@ -13,13 +13,16 @@ jobs:
       - name: Close issues referenced by Closes/Fixes/Resolves
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set -euo pipefail
+          # Extract issue numbers from any line containing a Closes/Fixes/Resolves
+          # keyword. Supports comma-lists like "Closes #1, #2, #3".
           issues=$(printf '%s\n' "$PR_BODY" \
-            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -iE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\b' \
             | grep -oE '#[0-9]+' \
             | tr -d '#' \
             | sort -u)

--- a/.github/workflows/label-cleanup.yml
+++ b/.github/workflows/label-cleanup.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Remove agent-ready and awaiting-review labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
           gh issue edit "$ISSUE" --remove-label agent-ready --remove-label awaiting-review || true


### PR DESCRIPTION
The close-on-develop-merge regex required whitespace between the keyword and #N, so "Closes #1, #2, #3" only matched #1. Loosen to: any line with a Closes/Fixes/Resolves keyword contributes all #N references on that line. Also set GH_REPO so gh commands work without a checkout (previous runs failed with "fatal: not a git repository").

Apply the same GH_REPO fix to label-cleanup.

Closes #183 #184 