### PR TITLE
feat(playground): tracer slice — schema runtime + Button entry at /

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -1,65 +1,78 @@
-import Image from 'next/image';
+'use client';
 
-export default function Home() {
+import * as React from 'react';
+import { SchemaRuntime } from '@/playground/schema/runtime';
+import { schemaRegistry } from '@/playground/schema/registry';
+import { cn } from '@/registry/lib/utils';
+
+const INTRODUCTION_KEY = '__introduction__';
+
+export default function PlaygroundHome() {
+  const [selected, setSelected] = React.useState<string>(INTRODUCTION_KEY);
+  const schema = schemaRegistry.find((entry) => entry.component === selected);
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{' '}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{' '}
-            or the{' '}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{' '}
-            center.
-          </p>
+    <div className="flex h-[calc(100vh-var(--header-height))] w-full">
+      <nav className="w-56 shrink-0 border-r border-line p-4">
+        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-foreground-subtle">
+          Components
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
+        <ul className="flex flex-col gap-0.5">
+          <SidebarItem
+            label="Introduction"
+            active={selected === INTRODUCTION_KEY}
+            onClick={() => setSelected(INTRODUCTION_KEY)}
+          />
+          {schemaRegistry.map((entry) => (
+            <SidebarItem
+              key={entry.component}
+              label={entry.name}
+              active={selected === entry.component}
+              onClick={() => setSelected(entry.component)}
             />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
+          ))}
+        </ul>
+      </nav>
+
+      {schema ? (
+        <SchemaRuntime schema={schema} />
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <div className="max-w-md text-center">
+            <h1 className="text-2xl font-semibold text-foreground">Introduction</h1>
+            <p className="mt-2 text-sm text-foreground-subtle">
+              Select a component from the sidebar to start exploring.
+            </p>
+          </div>
         </div>
-      </main>
+      )}
     </div>
+  );
+}
+
+function SidebarItem({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'w-full rounded-dynamic px-2 py-1 text-left text-sm',
+          active
+            ? 'bg-ui text-foreground'
+            : 'text-foreground-subtle hover:bg-hover/30 hover:text-foreground'
+        )}
+      >
+        {label}
+      </button>
+    </li>
   );
 }

--- a/apps/www/playground/schema/entries/button.ts
+++ b/apps/www/playground/schema/entries/button.ts
@@ -1,0 +1,21 @@
+import { createElement } from 'react';
+import { Button } from '@/registry/ui/button';
+import type { EntrySchema } from '../types';
+
+export const buttonEntry: EntrySchema = {
+  component: 'button',
+  name: 'Button',
+  variants: {
+    variant: {
+      values: ['solid', 'outline', 'surface', 'soft', 'ghost'],
+      label: 'Variant',
+      default: 'solid',
+    },
+  },
+  render: ({ variants }) =>
+    createElement(
+      Button,
+      { variant: variants.variant as 'solid' | 'outline' | 'surface' | 'soft' | 'ghost' },
+      'Button'
+    ),
+};

--- a/apps/www/playground/schema/registry.ts
+++ b/apps/www/playground/schema/registry.ts
@@ -1,0 +1,8 @@
+import type { EntrySchema } from './types';
+import { buttonEntry } from './entries/button';
+
+export const schemaRegistry: EntrySchema[] = [buttonEntry];
+
+export function getSchemaBySlug(slug: string): EntrySchema | undefined {
+  return schemaRegistry.find((entry) => entry.component === slug);
+}

--- a/apps/www/playground/schema/runtime.tsx
+++ b/apps/www/playground/schema/runtime.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import * as React from 'react';
+import type { EntrySchema, EntryState } from './types';
+import { defaultState } from './types';
+
+interface SchemaRuntimeProps {
+  schema: EntrySchema;
+}
+
+export function SchemaRuntime({ schema }: SchemaRuntimeProps) {
+  const [state, setState] = React.useState<EntryState>(() => defaultState(schema));
+
+  React.useEffect(() => {
+    setState(defaultState(schema));
+  }, [schema]);
+
+  const setVariant = (key: string, value: string) => {
+    setState((prev) => ({ ...prev, variants: { ...prev.variants, [key]: value } }));
+  };
+
+  return (
+    <>
+      <div className="flex flex-1 items-center justify-center p-8">{schema.render(state)}</div>
+      <aside className="w-64 shrink-0 border-l border-line p-4">
+        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-foreground-subtle">
+          {schema.name}
+        </div>
+        <div className="flex flex-col gap-3">
+          {Object.entries(schema.variants).map(([key, spec]) => (
+            <label key={key} className="flex flex-col gap-1 text-sm">
+              <span className="text-foreground-subtle">{spec.label ?? key}</span>
+              <select
+                className="rounded-dynamic border border-line-ui bg-ui px-2 py-1 text-sm text-foreground"
+                value={state.variants[key]}
+                onChange={(e) => setVariant(key, e.target.value)}
+              >
+                {spec.values.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ))}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/apps/www/playground/schema/types.ts
+++ b/apps/www/playground/schema/types.ts
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+export type VariantSpec = {
+  values: readonly string[];
+  label?: string;
+  default: string;
+};
+
+export type EntrySchema = {
+  component: string;
+  name: string;
+  variants: Record<string, VariantSpec>;
+  render: (state: EntryState) => ReactNode;
+};
+
+export type EntryState = {
+  variants: Record<string, string>;
+};
+
+export function defaultState(schema: EntrySchema): EntryState {
+  const variants: Record<string, string> = {};
+  for (const [key, spec] of Object.entries(schema.variants)) {
+    variants[key] = spec.default;
+  }
+  return { variants };
+}


### PR DESCRIPTION
## Summary
- First end-to-end vertical slice of the schema-driven Playground (ADR-0004, ADR-0005).
- `/` now shows a sidebar (Introduction + Button), preview area, and a generic toolbar driven by a per-Component `EntrySchema`.
- Button is authored as data; the schema runtime hard-codes no Component.

Closes #197.

## What's in
- `apps/www/playground/schema/types.ts` — `EntrySchema`, `VariantSpec`, `EntryState`, `defaultState`.
- `apps/www/playground/schema/runtime.tsx` — generic `SchemaRuntime` rendering preview + toolbar from any schema.
- `apps/www/playground/schema/entries/button.ts` — Button entry as data (one `variant` prop).
- `apps/www/playground/schema/registry.ts` — schema list + slug lookup.
- `apps/www/app/page.tsx` — Playground shell at `/` (sidebar + preview + toolbar).

## Out of scope (per issue body)
- Header theme controls, "Get code", URL/localStorage persistence, additional props, additional Components.
- Existing `/playground/<component>` routes and hand-authored entries are untouched.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm build` succeeds; `/` listed as static route
- [x] User confirmed `/` renders sidebar + preview + toolbar; Button select live-updates preview
- [x] Reviewer to sanity-check `/playground/<component>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)