### PR TITLE
feat(playground): add size + theme Variants to Button entry

### DIFF
--- a/apps/www/playground/schema/entries/button.ts
+++ b/apps/www/playground/schema/entries/button.ts
@@ -11,11 +11,25 @@ export const buttonEntry: EntrySchema = {
       label: 'Variant',
       default: 'solid',
     },
+    size: {
+      values: ['sm', 'md', 'lg', 'icon', 'icon-sm', 'icon-lg'],
+      label: 'Size',
+      default: 'md',
+    },
+    theme: {
+      values: ['gray', 'accent', 'destructive'],
+      label: 'Theme',
+      default: 'gray',
+    },
   },
   render: ({ variants }) =>
     createElement(
       Button,
-      { variant: variants.variant as 'solid' | 'outline' | 'surface' | 'soft' | 'ghost' },
+      {
+        variant: variants.variant as 'solid' | 'outline' | 'surface' | 'soft' | 'ghost',
+        size: variants.size as 'sm' | 'md' | 'lg' | 'icon' | 'icon-sm' | 'icon-lg',
+        theme: variants.theme,
+      },
       'Button'
     ),
 };


### PR DESCRIPTION
## Summary
- Extends Button's schema entry with `size` and `theme` Variants alongside the existing `variant` (closes #198).
- Defaults match Button's CVA `defaultVariants`: `variant: solid`, `size: md`, `theme: gray`.
- No runtime changes — the generic schema runtime from #197 picks up new Variants automatically.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Verified locally: three `<select>`s render in toolbar; changing any updates the preview live

🤖 Generated with [Claude Code](https://claude.com/claude-code)