### PR TITLE
feat(playground): URL state encoding for SchemaRuntime (#200)

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import '@/registry/theme/globals.css';
 import './layout.css';
 // import './app.css';
@@ -27,17 +28,19 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn(geist.variable, geistMono.variable)} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col font-sans antialiased">
-        <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
-          <div className="RootLayout">
-            <div className="RootLayoutContainer">
-              <div className="RootLayoutContent">
-                <Header />
-                <main>{children}</main>
+        <NuqsAdapter>
+          <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
+            <div className="RootLayout">
+              <div className="RootLayoutContainer">
+                <div className="RootLayoutContent">
+                  <Header />
+                  <main>{children}</main>
+                </div>
+                <span className="AppFooter"></span>
               </div>
-              <span className="AppFooter"></span>
             </div>
-          </div>
-        </ThemeProvider>
+          </ThemeProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -1,81 +1,10 @@
-'use client';
+import { Suspense } from 'react';
+import { PlaygroundHome } from './playground-home';
 
-import { useQueryState, parseAsString } from 'nuqs';
-import { SchemaRuntime } from '@/playground/schema/runtime';
-import { schemaRegistry } from '@/playground/schema/registry';
-import { cn } from '@/registry/lib/utils';
-
-const INTRODUCTION_KEY = '__introduction__';
-
-export default function PlaygroundHome() {
-  const [selected, setSelected] = useQueryState(
-    'c',
-    parseAsString.withDefault(INTRODUCTION_KEY).withOptions({ history: 'replace' })
-  );
-  const schema = schemaRegistry.find((entry) => entry.component === selected);
-
+export default function Page() {
   return (
-    <div className="flex h-[calc(100vh-var(--header-height))] w-full">
-      <nav className="w-56 shrink-0 border-r border-line p-4">
-        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-foreground-subtle">
-          Components
-        </div>
-        <ul className="flex flex-col gap-0.5">
-          <SidebarItem
-            label="Introduction"
-            active={selected === INTRODUCTION_KEY}
-            onClick={() => setSelected(INTRODUCTION_KEY)}
-          />
-          {schemaRegistry.map((entry) => (
-            <SidebarItem
-              key={entry.component}
-              label={entry.name}
-              active={selected === entry.component}
-              onClick={() => setSelected(entry.component)}
-            />
-          ))}
-        </ul>
-      </nav>
-
-      {schema ? (
-        <SchemaRuntime schema={schema} />
-      ) : (
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <h1 className="text-2xl font-semibold text-foreground">Introduction</h1>
-            <p className="mt-2 text-sm text-foreground-subtle">
-              Select a component from the sidebar to start exploring.
-            </p>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SidebarItem({
-  label,
-  active,
-  onClick,
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <li>
-      <button
-        type="button"
-        onClick={onClick}
-        className={cn(
-          'w-full rounded-dynamic px-2 py-1 text-left text-sm',
-          active
-            ? 'bg-ui text-foreground'
-            : 'text-foreground-subtle hover:bg-hover/30 hover:text-foreground'
-        )}
-      >
-        {label}
-      </button>
-    </li>
+    <Suspense>
+      <PlaygroundHome />
+    </Suspense>
   );
 }

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { useQueryState, parseAsString } from 'nuqs';
 import { SchemaRuntime } from '@/playground/schema/runtime';
 import { schemaRegistry } from '@/playground/schema/registry';
 import { cn } from '@/registry/lib/utils';
@@ -8,7 +8,10 @@ import { cn } from '@/registry/lib/utils';
 const INTRODUCTION_KEY = '__introduction__';
 
 export default function PlaygroundHome() {
-  const [selected, setSelected] = React.useState<string>(INTRODUCTION_KEY);
+  const [selected, setSelected] = useQueryState(
+    'c',
+    parseAsString.withDefault(INTRODUCTION_KEY).withOptions({ history: 'replace' })
+  );
   const schema = schemaRegistry.find((entry) => entry.component === selected);
 
   return (

--- a/apps/www/app/playground-home.tsx
+++ b/apps/www/app/playground-home.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useQueryState, parseAsString } from 'nuqs';
+import { SchemaRuntime } from '@/playground/schema/runtime';
+import { schemaRegistry } from '@/playground/schema/registry';
+import { cn } from '@/registry/lib/utils';
+
+const INTRODUCTION_KEY = '__introduction__';
+
+export function PlaygroundHome() {
+  const [selected, setSelected] = useQueryState(
+    'c',
+    parseAsString.withDefault(INTRODUCTION_KEY).withOptions({ history: 'replace' })
+  );
+  const schema = schemaRegistry.find((entry) => entry.component === selected);
+
+  return (
+    <div className="flex h-[calc(100vh-var(--header-height))] w-full">
+      <nav className="w-56 shrink-0 border-r border-line p-4">
+        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-foreground-subtle">
+          Components
+        </div>
+        <ul className="flex flex-col gap-0.5">
+          <SidebarItem
+            label="Introduction"
+            active={selected === INTRODUCTION_KEY}
+            onClick={() => setSelected(INTRODUCTION_KEY)}
+          />
+          {schemaRegistry.map((entry) => (
+            <SidebarItem
+              key={entry.component}
+              label={entry.name}
+              active={selected === entry.component}
+              onClick={() => setSelected(entry.component)}
+            />
+          ))}
+        </ul>
+      </nav>
+
+      {schema ? (
+        <SchemaRuntime schema={schema} />
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <div className="max-w-md text-center">
+            <h1 className="text-2xl font-semibold text-foreground">Introduction</h1>
+            <p className="mt-2 text-sm text-foreground-subtle">
+              Select a component from the sidebar to start exploring.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SidebarItem({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'w-full rounded-dynamic px-2 py-1 text-left text-sm',
+          active
+            ? 'bg-ui text-foreground'
+            : 'text-foreground-subtle hover:bg-hover/30 hover:text-foreground'
+        )}
+      >
+        {label}
+      </button>
+    </li>
+  );
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -34,6 +34,7 @@
     "fumadocs-ui": "^16.6.13",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.8.9",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "shadcn": "^4.0.2",

--- a/apps/www/playground/schema/runtime.tsx
+++ b/apps/www/playground/schema/runtime.tsx
@@ -1,26 +1,66 @@
 'use client';
 
 import * as React from 'react';
+import { useQueryStates, parseAsString, parseAsBoolean } from 'nuqs';
 import type { EntrySchema, EntryState, InputSpec } from './types';
-import { defaultState } from './types';
+
+type SchemaParser =
+  | ReturnType<typeof parseAsString.withDefault>
+  | ReturnType<typeof parseAsBoolean.withDefault>;
 
 interface SchemaRuntimeProps {
   schema: EntrySchema;
 }
 
-export function SchemaRuntime({ schema }: SchemaRuntimeProps) {
-  const [state, setState] = React.useState<EntryState>(() => defaultState(schema));
+function buildSchemaParsers(schema: EntrySchema) {
+  const parsers: Record<string, SchemaParser> = {};
+  const prefix = `${schema.component}-`;
+  const variantKeys: string[] = [];
+  const inputKeys: string[] = [];
 
-  React.useEffect(() => {
-    setState(defaultState(schema));
-  }, [schema]);
+  for (const [key, spec] of Object.entries(schema.variants)) {
+    parsers[prefix + key] = parseAsString.withDefault(spec.default);
+    variantKeys.push(key);
+  }
+  if (schema.content) {
+    for (const [key, spec] of Object.entries(schema.content)) {
+      parsers[prefix + key] =
+        spec.type === 'boolean'
+          ? parseAsBoolean.withDefault(spec.default)
+          : parseAsString.withDefault(spec.default);
+      inputKeys.push(key);
+    }
+  }
+
+  return { parsers, prefix, variantKeys, inputKeys };
+}
+
+export function SchemaRuntime({ schema }: SchemaRuntimeProps) {
+  const { parsers, prefix, variantKeys, inputKeys } = React.useMemo(
+    () => buildSchemaParsers(schema),
+    [schema]
+  );
+
+  const [urlState, setUrlState] = useQueryStates(parsers, { history: 'replace' });
+
+  const state: EntryState = React.useMemo(() => {
+    const variants: Record<string, string> = {};
+    for (const key of variantKeys) {
+      variants[key] = urlState[prefix + key] as string;
+    }
+    const inputs: Record<string, unknown> = {};
+    for (const key of inputKeys) {
+      inputs[key] = urlState[prefix + key];
+    }
+    return { variants, inputs };
+  }, [urlState, variantKeys, inputKeys, prefix]);
 
   const setVariant = (key: string, value: string) => {
-    setState((prev) => ({ ...prev, variants: { ...prev.variants, [key]: value } }));
+    setUrlState({ [prefix + key]: value });
   };
 
   const setInput = (key: string, value: unknown) => {
-    setState((prev) => ({ ...prev, inputs: { ...prev.inputs, [key]: value } }));
+    setUrlState({ [prefix + key]: value as string | boolean });
   };
 
   const hasContent = schema.content && Object.keys(schema.content).length > 0;

--- a/apps/www/pnpm-lock.yaml
+++ b/apps/www/pnpm-lock.yaml
@@ -42,10 +42,13 @@ importers:
         version: 16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.3))(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.2.1)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1967,6 +1970,12 @@ packages:
         integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==,
       }
     engines: { node: '>=18' }
+
+  '@standard-schema/spec@1.0.0':
+    resolution:
+      {
+        integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==,
+      }
 
   '@standard-schema/spec@1.1.0':
     resolution:
@@ -5684,6 +5693,30 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
+  nuqs@2.8.9:
+    resolution:
+      {
+        integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==,
+      }
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
+
   object-assign@4.1.1:
     resolution:
       {
@@ -8589,6 +8622,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -11182,6 +11217,32 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    optional: true
+
+  next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@next/env': 16.1.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001777
+      postcss: 8.4.31
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.59.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   node-domexception@1.0.0: {}
 
@@ -11210,6 +11271,13 @@ snapshots:
       unicorn-magic: 0.3.0
 
   npm-to-yarn@3.0.1: {}
+
+  nuqs@2.8.9(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.3
+    optionalDependencies:
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   object-assign@4.1.1: {}
 
@@ -12016,6 +12084,12 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@babel/core': 7.29.0
+    optional: true
+
+  styled-jsx@5.1.6(react@19.2.3):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
 
   supports-color@7.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -2739,6 +2742,12 @@ packages:
         integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==,
       }
     engines: { node: '>=18' }
+
+  '@standard-schema/spec@1.0.0':
+    resolution:
+      {
+        integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==,
+      }
 
   '@standard-schema/spec@1.1.0':
     resolution:
@@ -7164,6 +7173,30 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
+  nuqs@2.8.9:
+    resolution:
+      {
+        integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==,
+      }
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
+
   object-assign@4.1.1:
     resolution:
       {
@@ -11046,6 +11079,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -14048,6 +14083,13 @@ snapshots:
       unicorn-magic: 0.3.0
 
   npm-to-yarn@3.0.1: {}
+
+  nuqs@2.8.9(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.3
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
## Summary
- Generic URL encoding wired into `SchemaRuntime` via nuqs — variants + content inputs serialize to prefixed query params (`${component}-${key}`), defaults are stripped, history uses `replaceState`
- Selected component persists on `?c=` so reloading or sharing a URL restores both the selected entry and its toolbar/content state
- Per-component scoping comes for free via the key prefix; unknown URL keys are ignored
- Adding a new variant or content input in an entry requires no changes in the URL layer

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` pass
- [x] Changing any control on `/` updates the URL via `replaceState`
- [x] Loading `/?c=button&button-variant=outline&button-label=Save` restores the same state
- [x] Clearing back to defaults yields a clean URL
- [x] Switching to a different component starts fresh

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)