### PR TITLE
fix(sandcastle): enforce branch discipline and verify commits post-run

### DIFF
--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -18,9 +18,12 @@ accessible, composable UI primitives. Package manager: **pnpm**.
 3. **Plan** — decide the smallest change that satisfies the issue.
 4. **Execute** — keep edits tightly scoped. No refactoring of surrounding
    code. No commented-out code, no `TODO`s, no new `any` casts.
+   Stay on the branch you started on — see shared protocol for the
+   forbidden git commands. Violating this strands your work.
 5. **Verify gates** — see shared protocol below. If a gate fails and you
    cannot fix it after a genuine attempt, stop with BLOCKED — never emit
-   COMPLETE without a green committed build.
+   COMPLETE without a green committed build. Do not rationalize a failing
+   gate as "environment-related" — emit BLOCKED with the failing output.
 6. **Commit** — single commit, format per shared protocol.
 
 ## Rules
@@ -32,13 +35,16 @@ accessible, composable UI primitives. Package manager: **pnpm**.
 
 # Done
 
-Before declaring COMPLETE, verify you actually committed:
+Before declaring COMPLETE, verify both:
 
 ```
-git log --oneline --grep="^sandcastle-" -1
+git branch --show-current   # must equal the branch you started on
+git log --oneline --grep="^sandcastle-" -1   # must show your commit
 ```
 
-If empty, you have not committed — output BLOCKED per shared protocol.
+If you are on a different branch, or the log is empty, you have not
+successfully landed work on the expected ref — output BLOCKED per shared
+protocol with the failing output included.
 
 Otherwise, output the title, summary, and completion signal in one final
 message (do not split across messages):

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -103,7 +103,7 @@ const resolveAgent = (envVar: string, fallback: string): AgentProvider => {
       });
     case 'claude-code':
       return sandcastle.claudeCode(model, {
-        env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+        env: { CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN! },
       });
     case 'codex':
       return sandcastle.codex(model, {

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -335,8 +335,81 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     continue;
   }
 
-  if (!implement.commits.length) {
-    console.log('Implementation agent made no commits. Skipping review.');
+  // Verify commits independently rather than trusting implement.commits.length
+  // alone — agents have been observed switching branches mid-run, stranding
+  // their commits on a ref the orchestrator doesn't watch. See #213.
+  const expectedCommits = execSync(
+    `git log ${baseBranch}..${implementBranch} --oneline 2>/dev/null || true`,
+    { encoding: 'utf8' }
+  ).trim();
+
+  if (!expectedCommits) {
+    // No commits on the expected branch. Check whether the agent stranded
+    // them on a different agent-* branch in the worktree.
+    const allAgentBranches = execSync(`git branch --format='%(refname:short)' --list 'agent-*'`, {
+      encoding: 'utf8',
+    })
+      .trim()
+      .split('\n')
+      .filter((b) => b && b !== implementBranch);
+
+    const strandedBranches = allAgentBranches
+      .map((b) => {
+        const count = parseInt(
+          execSync(`git rev-list --count ${baseBranch}..${b} 2>/dev/null || echo 0`, {
+            encoding: 'utf8',
+          }).trim(),
+          10
+        );
+        return count > 0 ? `${b} (${count} commits)` : null;
+      })
+      .filter((x): x is string => x !== null)
+      .join('\n');
+
+    const issueRef =
+      targetIssue ??
+      implement.stdout.match(/<working-on-issue>(\d+)<\/working-on-issue>/)?.[1] ??
+      null;
+    const logPath = `.sandcastle/logs/${implementBranch.replace(/\//g, '-')}.log`;
+
+    if (strandedBranches) {
+      console.error(
+        `\n⚠️  Agent committed to a different branch than expected.\n` +
+          `   Expected: ${implementBranch} (0 commits)\n` +
+          `   Found commits on:\n${strandedBranches
+            .split('\n')
+            .map((b) => `     - ${b}`)
+            .join('\n')}\n` +
+          `   Log: ${logPath}\n` +
+          `   Manual recovery required — do not silently skip.`
+      );
+      if (issueRef) {
+        const body = `**Sandcastle: agent committed to wrong branch.**\n\nExpected commits on \`${implementBranch}\` but found them on:\n\`\`\`\n${strandedBranches}\n\`\`\`\nLog: \`${logPath}\`\n\nLikely cause: agent ran a forbidden branch-mutating git command (see #213). Manual recovery needed.`;
+        try {
+          execSync(`gh issue comment ${issueRef} --body ${JSON.stringify(body)}`, {
+            stdio: 'inherit',
+          });
+        } catch {
+          console.warn(`Could not post stranded-branch comment to issue #${issueRef}`);
+        }
+      }
+    } else {
+      console.error(
+        `\n⚠️  Agent emitted COMPLETE but produced no commits on any branch.\n` +
+          `   Log: ${logPath}\n` +
+          `   Likely cause: gate failure rationalized, or no-op completion.`
+      );
+      if (issueRef) {
+        const body = `**Sandcastle: agent reported COMPLETE but produced no commits.**\n\nBranch: \`${implementBranch}\`\nLog: \`${logPath}\`\n\nLikely cause: branch switch, gate failure rationalized as "environment", or no-op completion. See #213.`;
+        try {
+          execSync(`gh issue comment ${issueRef} --body ${JSON.stringify(body)}`, {
+            stdio: 'inherit',
+          });
+        } catch {
+          console.warn(`Could not post zero-commit comment to issue #${issueRef}`);
+        }
+      }
+    }
     continue;
   }
 

--- a/.sandcastle/shared.md
+++ b/.sandcastle/shared.md
@@ -1,5 +1,19 @@
 # Shared protocol
 
+## Branch discipline
+
+The branch you start on is the only branch you may touch. Forbidden commands:
+
+- `git checkout -b ...`
+- `git switch -c ...`
+- `git branch <new>`
+- `git branch -m ...`
+- `git worktree add ...`
+
+If you believe a different branch is needed, emit BLOCKED with the reason —
+do not act on it. Violation here strands work on a branch the orchestrator
+cannot find and produces silent zero-commit runs.
+
 ## Gates
 
 Before any commit, both must pass:
@@ -8,6 +22,11 @@ Before any commit, both must pass:
 - `pnpm lint`
 
 Never use `--no-verify` or any flag that skips hooks. Fix root causes.
+
+A gate failure you cannot resolve → emit BLOCKED. Never rationalize a
+failing gate as "environment-related" or "unrelated to my changes" and
+proceed to COMPLETE. If gates are red, the only valid outcomes are: fix
+them, or BLOCKED.
 
 ## Commit format
 


### PR DESCRIPTION
## Summary

- Forbids branch-mutating git commands (`checkout -b`, `switch -c`, `branch -m`, `worktree add`) at the shared-protocol level; bans "environment issue" rationalization for failing gates
- Strengthens pre-COMPLETE check in the implementer prompt to verify the agent is still on its original branch
- Replaces blind `implement.commits.length` check in the orchestrator with `git log <base>..<branch>` verification; detects stranded-branch case (commits on a different `agent-*` ref) and posts a synthetic comment on the referenced issue instead of silently skipping
- Also folds in a small fix to use `CLAUDE_CODE_OAUTH_TOKEN` for the claude-code provider, matching `.sandcastle/.env` (separate commit)

## Context

Observed against #187 and #188 runs: agents either rationalized gate failures as "environment-related" then emitted COMPLETE without committing (#187), or switched branches mid-run and committed to a ref the orchestrator wasn't watching (#188 — work landed on `agent-feat/sandcastle-v2-orchestrator-dry-run` while sandcastle counted commits on `agent-wip/issue-188`). In both cases the orchestrator silently logged "no commits" and skipped review, providing no signal that work might be stranded.

These guardrails are needed for the legacy path now (HITL coverage until #189 lands the v2 `--execute` lane) and should be inherited by `implement-fresh.md` in #189.

## Test plan

- [ ] Trigger a `pnpm sandcastle --issue <N> --branch agent-<type>/<scope>` run that produces a valid commit on the supplied branch — verify draft PR opens as before
- [ ] Force the stranded-branch case (e.g. provoke an agent to create a sibling `agent-*` branch) — verify orchestrator logs loudly AND posts a comment to the referenced issue, no silent skip
- [ ] Force a zero-commit COMPLETE (no edits / gate failure / no-op) — verify orchestrator posts a synthetic comment on the issue with the log path

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)