### PR TITLE
fix(sandcastle): install Claude Code CLI in agent Dockerfile

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -29,8 +29,10 @@ RUN existing=$(getent group $AGENT_GID | cut -d: -f1); \
     groupmod -g $AGENT_GID node && \
     usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
-# Install pnpm and pi coding agent (run as root before USER agent)
-RUN npm install -g pnpm @mariozechner/pi-coding-agent
+# Install pnpm and the coding agent CLIs (run as root before USER agent).
+# Both providers ship as global npm packages; the orchestrator's resolveAgent
+# picks one at dispatch time based on SANDCASTLE_IMPL_AGENT.
+RUN npm install -g pnpm @mariozechner/pi-coding-agent @anthropic-ai/claude-code
 
 # Ensure the home dir is accessible regardless of runtime UID
 RUN chmod -R a+rwX /home/agent


### PR DESCRIPTION
## Summary

The orchestrator's `resolveAgent` in [main.v2.mts](.sandcastle/main.v2.mts) (and the legacy `main.mts`) wires the `claude-code` provider, but `.sandcastle/Dockerfile` only installed `@mariozechner/pi-coding-agent`. Setting `SANDCASTLE_IMPL_AGENT=claude-code:<model>` caused runs to fail immediately with `claude: not found` (exit 127).

This adds `@anthropic-ai/claude-code` to the global npm install in the same `RUN` line.

## Verification

- Image rebuild + `claude --version` smoke test is a manual step post-merge (the host needs to rebuild the sandcastle image once the change lands).
- No orchestrator or prompt changes required — the provider selection logic was already in place; this just makes the binary it shells out to actually exist.

## Test plan

- [ ] Rebuild sandcastle image after merge
- [ ] Confirm `docker run --rm <image> claude --version` returns a version string
- [ ] Run `pnpm sandcastle:v2 --execute` with `SANDCASTLE_IMPL_AGENT=claude-code:<model>` against a trivial test issue and confirm the agent runs (not just the orchestrator)

Closes #219