### PR TITLE
fix(sandcastle): drop SOURCE_BRANCH from reviewer promptArgs

### DIFF
--- a/.sandcastle/main.v2.mts
+++ b/.sandcastle/main.v2.mts
@@ -533,10 +533,11 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
     maxIterations: 5,
     agent: reviewerAgent,
     promptFile: './.sandcastle/review-prompt.md',
+    // SOURCE_BRANCH/TARGET_BRANCH are sandcastle built-ins injected from
+    // branchStrategy — passing them here errors with PromptError.
     promptArgs: {
       PR_NUMBER: String(prNumber),
       BRANCH: branch,
-      SOURCE_BRANCH: prData.baseRefName,
       PR_BODY: prData.body ?? '(no description)',
       REVIEW_THREAD: reviewThread,
       SHARED,


### PR DESCRIPTION
## Summary

- \`SOURCE_BRANCH\` and \`TARGET_BRANCH\` are built-in sandcastle prompt arguments injected automatically from \`branchStrategy\`. Passing them via \`promptArgs\` triggers \`PromptError\` and aborts the reviewer dispatch before the agent runs.
- Discovered while exercising the reviewer slice against PR #224 (after merging #225 unblocked the reviewer action).

## Test plan

- [x] \`pnpm typecheck\` green
- [ ] After merge: \`pnpm sandcastle:v2 --execute\` reaches the reviewer agent against #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)