### PR TITLE
fix(sandcastle): escape agent-fill placeholders in review prompt

### DIFF
--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -68,8 +68,8 @@ incorrect behavior, incomplete scope.
 </review-summary>
 
 <comments>
-- **{{FILE}}:{{LINE}}** — comment text
-- **{{FILE}}:{{LINE}}** — comment text
+- **<FILE>:<LINE>** — comment text
+- **<FILE>:<LINE>** — comment text
 </comments>
 ```
 
@@ -84,10 +84,10 @@ Leave line-anchored comments via `gh api`:
 ```bash
 gh api repos/ora-ui/ora-ui/pulls/{{PR_NUMBER}}/comments \
   --method POST \
-  --field body="**{{FILE}}:{{LINE}}** — comment text" \
+  --field body="**<FILE>:<LINE>** — comment text" \
   --field commit_id="$(git rev-parse origin/{{BRANCH}})" \
-  --field path="{{FILE}}" \
-  --field line={{LINE}}
+  --field path="<FILE>" \
+  --field line=<LINE>
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Sandcastle treats every \`{{IDENT}}\` in a \`promptFile\` as a required template variable. The reviewer prompt used \`{{FILE}}\` / \`{{LINE}}\` as example placeholders for the agent to fill in when writing line-anchored comments — sandcastle tried to substitute them and aborted with \`PromptError: Prompt argument "{{FILE}}" has no matching value in promptArgs\` before the agent ran.
- Rename the agent-fill placeholders to \`<FILE>\` / \`<LINE>\` so sandcastle's regex skips them. Real template vars (\`PR_NUMBER\`, \`BRANCH\`, \`SOURCE_BRANCH\`, \`PR_BODY\`, \`REVIEW_THREAD\`, \`SHARED\`) unchanged.
- Discovered while running \`pnpm sandcastle:v2 --execute\` against PR #224 after merging #225 and #226.

## Test plan

- [x] \`pnpm typecheck\` green
- [ ] After merge: \`pnpm sandcastle:v2 --execute\` reaches the reviewer agent and produces one of the three outcomes against #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)