### PR TITLE
fix(sandcastle): bot uses comment-state review; humans own final approval

### DIFF
--- a/.sandcastle/main.v2.mts
+++ b/.sandcastle/main.v2.mts
@@ -139,42 +139,14 @@ function ghJsonSafe<T>(query: string, fallback: T): T {
   }
 }
 
-// Post-verify the agent's review submission landed. Labels and draft state are
-// orchestrator-managed (see applyReviewStateOps) so we only check reviewDecision
-// here — a GraphQL-only field, hence `gh pr view --json`, not REST.
-function verifyReviewOutcome(
-  prNumber: number,
-  expected: 'approved' | 'changes_requested'
-): { ok: true } | { ok: false; reason: string } {
-  let pr: { reviewDecision: string | null };
-  try {
-    pr = JSON.parse(
-      execSync(`gh pr view ${prNumber} --json reviewDecision`, {
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          GITHUB_TOKEN: process.env.GH_TOKEN ?? process.env.SANDCASTLE_BOT_TOKEN,
-        },
-      })
-    );
-  } catch (err) {
-    return { ok: false, reason: `gh pr view failed: ${(err as Error).message}` };
-  }
-
-  const expectedDecision = expected === 'approved' ? 'APPROVED' : 'CHANGES_REQUESTED';
-  if (pr.reviewDecision !== expectedDecision) {
-    return {
-      ok: false,
-      reason: `reviewDecision is ${pr.reviewDecision ?? 'null'}, expected ${expectedDecision}`,
-    };
-  }
-  return { ok: true };
-}
-
 // Apply label/draft state mutations after a review outcome. The reviewer prompt
-// only submits content (the formal review + inline comments); the orchestrator
+// only submits content (a comment-state review + inline comments); the orchestrator
 // owns all state transitions so failures here surface as orchestrator errors
 // rather than half-landed prompt-side gh sequences.
+//
+// Note: the bot cannot formally `--approve` its own PRs (GitHub blocks
+// self-approval). The agent-approved label is the canonical hand-off signal —
+// a human approves and merges from there. `reviewDecision` is not consulted.
 //
 // Idempotent: removing an already-absent label or adding an already-present one
 // is a no-op in gh.
@@ -729,22 +701,12 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
 
   if (approveMatch || requestChangesMatch) {
     const expected = approveMatch ? 'approved' : 'changes_requested';
-    const verification = verifyReviewOutcome(prNumber, expected);
-    if (!verification.ok) {
-      console.error(
-        `\nVerification failed for PR #${prNumber} (expected ${expected}): ${verification.reason}\n` +
-          `Reviewer emitted a promise but the formal review submission did not land. Manual recovery required.\n` +
-          `Log: ${logPath}`
-      );
-      process.exit(1);
-    }
     try {
       applyReviewStateOps(prNumber, expected, issueNumber);
     } catch (err) {
       console.error(
-        `\nState ops failed for PR #${prNumber} after verified ${expected} review: ${(err as Error).message}\n` +
-          `Review submission landed but label/draft state did not. Manual recovery required.\n` +
-          `Log: ${logPath}`
+        `\nState ops failed for PR #${prNumber} on ${expected} outcome: ${(err as Error).message}\n` +
+          `Manual recovery required. Log: ${logPath}`
       );
       process.exit(1);
     }

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -49,10 +49,10 @@ substantive gaps.
 </review-summary>
 ```
 
-Then submit the formal approval review (body is the `<review-summary>` text):
+Then post the review summary as a comment-state review (the bot cannot formally `--approve` its own PRs — that's blocked by GitHub. Final approval is human-only; the `agent-approved` label is the orchestrator's hand-off signal):
 
 ```bash
-gh pr review {{PR_NUMBER}} --approve --body "<review-summary text>"
+gh pr review {{PR_NUMBER}} --comment --body "<review-summary text>"
 ```
 
 ---
@@ -75,10 +75,10 @@ incorrect behavior, incomplete scope.
 </comments>
 ```
 
-Submit the formal request-changes review (body is the `<review-summary>` text):
+Post the review summary as a comment-state review (same self-review constraint as Option A; the `agent-impl-todo` label drives the address-review loop, not GitHub's `reviewDecision`):
 
 ```bash
-gh pr review {{PR_NUMBER}} --request-changes --body "<review-summary text>"
+gh pr review {{PR_NUMBER}} --comment --body "<review-summary text>"
 ```
 
 Then leave line-anchored comments via `gh api`:


### PR DESCRIPTION
## What this fixes

GitHub blocks self-approval — a bot cannot formally `gh pr review --approve` its own PR. Before this PR:

- `review-prompt.md` Option A called `gh pr review --approve` (gh errored: "Cannot approve your own pull request")
- `verifyReviewOutcome` enforced `reviewDecision === APPROVED`, so the orchestrator exited 1 on every clean approval
- Caught live on PR #231 — agent did everything correctly on merit, but the loop was structurally unblockable

## Resolution

- Reviewer prompt now calls `gh pr review --comment --body "..."` for both approve and request-changes paths. Comment-state reviews are allowed on own PRs and still surface in the reviews API for visibility.
- `verifyReviewOutcome` removed entirely. `reviewDecision` is no longer consulted; the agent-* labels (orchestrator-managed atomically via `applyReviewStateOps`) are the source of truth for state.
- Inline notes in both the prompt and `main.v2.mts` document the constraint so the rationale survives future refactors.

## Hand-off model

Bot reviews + flips labels → human approves and merges. Until a separate reviewer-identity exists (Phase 3+), this is the only viable single-identity flow on GitHub.

## Test plan

- [ ] Typecheck + lint green (verified locally)
- [ ] Dry-run the queue once after merge — confirm v2 picks expected work
- [ ] Next real reviewer dispatch round-trips without orchestrator exit-1