### PR TITLE
fix(sandcastle): stop reviewer agent looping and reposting reviews

### DIFF
--- a/.sandcastle/main.v2.mts
+++ b/.sandcastle/main.v2.mts
@@ -647,7 +647,13 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
   // REVIEW_COMMENTS is only populated with bot-authored comments — human inline
   // comments are not part of the reviewer agent loop and would confuse it.
   const existingComments = ghJsonSafe<
-    Array<{ path: string | null; line: number | null; body: string | null; user: { login: string }; createdAt: string }>
+    Array<{
+      path: string | null;
+      line: number | null;
+      body: string | null;
+      user: { login: string };
+      createdAt: string;
+    }>
   >(
     `repos/ora-ui/ora-ui/pulls/${prNumber}/comments --jq '[.[] | select(.user.login == "${BOT_LOGIN}") | {path: .path, line: .line, body: .body, user: {login: .user.login}, createdAt: .created_at}]'`,
     []
@@ -675,7 +681,12 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
     sandbox: docker({ env: botGitEnv }),
     branchStrategy: { type: 'branch', branch, baseBranch: prData.baseRefName },
     name: 'reviewer',
-    maxIterations: 5,
+    // Reviewer is a one-shot decision task — not an iterative build. Each
+    // sandcastle iteration is a fresh agent run with the original prompt args
+    // (REVIEW_THREAD/REVIEW_COMMENTS are snapshotted at dispatch), so retries
+    // don't see prior-iteration work and re-post the same review. If iter 1
+    // doesn't yield a promise tag, escalate instead of looping. See #234.
+    maxIterations: 1,
     agent: reviewerAgent,
     promptFile: './.sandcastle/review-prompt.md',
     // SOURCE_BRANCH/TARGET_BRANCH are sandcastle built-ins injected from
@@ -691,11 +702,20 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
     logging: { type: 'file', path: logPath },
   });
 
-  const approveMatch = result.stdout.match(/<promise>agent:review:approve<\/promise>/);
-  const requestChangesMatch = result.stdout.match(
-    /<promise>agent:review:request-changes<\/promise>/
-  );
-  const escalateMatch = result.stdout.match(/<promise>agent:review:escalate<\/promise>/);
+  // Search both result.stdout AND the on-disk log. result.stdout may be
+  // truncated, only-final-iteration, or otherwise lossy depending on provider;
+  // the log file is the canonical transcript. See #234 (promise-parse miss).
+  let logContents = '';
+  try {
+    logContents = readFileSync(logPath, 'utf8');
+  } catch {
+    // Log file missing is unexpected but non-fatal — fall back to stdout only.
+  }
+  const transcript = result.stdout + '\n' + logContents;
+
+  const approveMatch = transcript.match(/<promise>agent:review:approve<\/promise>/);
+  const requestChangesMatch = transcript.match(/<promise>agent:review:request-changes<\/promise>/);
+  const escalateMatch = transcript.match(/<promise>agent:review:escalate<\/promise>/);
 
   const issueNumber = extractClosingIssue(prData.body);
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -3,6 +3,17 @@
 Review the implementer's PR. **Default to no-op.** Take no action unless
 review work is clearly warranted.
 
+**This is a one-shot task.** Emit your `<promise>` tag exactly once, run the
+posting commands exactly once, then stop. Do not retry, re-post, or re-emit
+the promise — even if the run feels incomplete. If anything fails, escalate
+(Option C) rather than retrying.
+
+**Do not modify PR labels.** The orchestrator owns all label transitions
+(`agent-review-pending` → `agent-impl-todo`/`agent-approved`/`needs-human`)
+based on the promise tag you emit. Never call `gh pr edit --add-label` or
+`--remove-label`. If you do, the label state becomes inconsistent and the
+next orchestrator sweep will re-spawn this reviewer in a loop.
+
 ## Context
 
 ### PR metadata


### PR DESCRIPTION
## Summary

Reviewer agent ran 5 fresh iterations on PR #233 (the v2-lane PR for #193), posting the same review ~5 times. Orchestrator then exited 1 with "no recognizable promise" despite the promise tag being in the log, and the PR was left with both `agent-review-pending` AND `agent-impl-todo` — next sweep would have re-spawned the reviewer indefinitely.

Three coupled fixes:

- **`maxIterations: 5` → `1`** on the reviewer dispatch. Each sandcastle iteration is a fresh agent run with the original prompt args (`REVIEW_THREAD`/`REVIEW_COMMENTS` snapshotted at dispatch), so retries can't see prior-iteration work and re-do everything. Review is a one-shot decision, not an iterative build. If iter 1 doesn't yield a promise tag, escalate rather than loop.
- **Promise parsing reads both `result.stdout` and the on-disk log file.** Provider stdout was lossy on this run; the log file is the canonical transcript.
- **Reviewer prompt explicitly forbids `gh pr edit --add-label`/`--remove-label`** and emphasises one-shot semantics. Orchestrator owns all label transitions per #232.

## Test plan

- [ ] Address-review #233 with feedback from the previous (legit) review and re-run the reviewer; verify single review post, single promise tag, atomic `agent-review-pending` → `agent-impl-todo` or `agent-approved` transition.
- [ ] Manually verify on a clean PR that reviewer exits cleanly with a recognized promise on iter 1.
- [ ] Verify escalate path still works (no spurious approval-loop after fix).

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)