### PR TITLE
fix(sandcastle): rounds counter ignores empty-body auto-review shells; bump default cap to 3

### DIFF
--- a/.sandcastle/main.v2.mts
+++ b/.sandcastle/main.v2.mts
@@ -37,7 +37,7 @@ import { parseArgs } from 'node:util';
 // ---------------------------------------------------------------------------
 
 const BOT_LOGIN = process.env.SANDCASTLE_BOT_LOGIN ?? 'ora-gh-bot';
-const ROUNDS_CAP = parseInt(process.env.SANDCASTLE_ROUNDS_CAP ?? '2', 10);
+const ROUNDS_CAP = parseInt(process.env.SANDCASTLE_ROUNDS_CAP ?? '3', 10);
 const BASE_BRANCH = process.env.SANDCASTLE_BASE_BRANCH ?? 'develop';
 
 // Canonical bot git env passed into every docker dispatch. All dispatchers
@@ -228,12 +228,20 @@ function fetchDraftPRs(): PR[] {
 
   return raw.map((pr) => {
     const reviews = ghJsonSafe<
-      Array<{ user: { login: string }; submittedAt: string; state: string }>
+      Array<{ user: { login: string }; submittedAt: string; state: string; body: string | null }>
     >(
-      `repos/ora-ui/ora-ui/pulls/${pr.number}/reviews --jq '[.[] | {user: {login: .user.login}, submittedAt: .submitted_at, state}]'`,
+      `repos/ora-ui/ora-ui/pulls/${pr.number}/reviews --jq '[.[] | {user: {login: .user.login}, submittedAt: .submitted_at, state, body}]'`,
       []
     );
-    const botReviews = reviews.filter((r) => r.user.login === BOT_LOGIN);
+    // Filter to bot-authored reviews with a non-empty body. The line-anchored
+    // comments endpoint (POST /pulls/N/comments) auto-creates a Review record
+    // with empty body when no parent review ID is supplied — those are not
+    // distinct "rounds" of feedback and would otherwise double-count against
+    // ROUNDS_CAP. A real review submitted via `gh pr review --body=…` always
+    // carries the agent's summary text.
+    const botReviews = reviews.filter(
+      (r) => r.user.login === BOT_LOGIN && r.body !== null && r.body.trim() !== ''
+    );
 
     const commits = ghJsonSafe<Array<{ committedDate: string }>>(
       `repos/ora-ui/ora-ui/pulls/${pr.number}/commits --jq '[.[] | {committedDate: .commit.committer.date}]'`,


### PR DESCRIPTION
## Summary

PR #236 escalated to human after one review pass because the v2 rounds counter saw two `Review` records:

1. The actual review submitted via `gh pr review --comment --body "<summary>"`
2. An empty-body shell auto-created by `POST /repos/.../pulls/{n}/comments` when the agent posted the line-anchored inline comment

The comments endpoint implicitly creates a parent review when no `pull_request_review_id` is supplied. That second shell isn't a distinct round of feedback — it's an API artifact of how single inline comments are persisted. Counting it against `ROUNDS_CAP` doubles the effective cap consumption per real round.

Two changes:

- **`fetchDraftPRs`: filter bot reviews to non-empty bodies.** A real review submitted via `gh pr review --body=…` always carries the agent's summary text. Empty-body reviews in our flow are always auto-created shells.
- **Default `ROUNDS_CAP`: 2 → 3.** The previous cap left zero headroom (initial review + 1 address-review pass = cap). 3 allows one full back-and-forth (initial review + 2 address-review passes), which matches typical PR rhythm without enabling runaway loops. Override via `SANDCASTLE_ROUNDS_CAP` env var as before.

## Test plan

- [ ] Verify on #236 (manually unblock + re-run address-review) that rounds counter now reports 1/3 after the initial review pass.
- [ ] Verify rounds-cap still escalates correctly on a synthetic PR that genuinely reviewed 3+ times.
- [ ] Confirm `SANDCASTLE_ROUNDS_CAP` env override still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)