### PR TITLE
fix(sandcastle): dispatchAddressReview missing REST→camelCase jq projection

### DIFF
--- a/.sandcastle/main.v2.mts
+++ b/.sandcastle/main.v2.mts
@@ -778,7 +778,11 @@ async function dispatchAddressReview(prNumber: number): Promise<void> {
     baseRefName: string;
     headSha: string;
   }>(
-    `repos/ora-ui/ora-ui/pulls/${prNumber} --jq '{number, title, body, headRefName, baseRefName, headSha}'`
+    // The REST shape returns nested head.ref/base.ref/head.sha — project them
+    // to camelCase here so the TS types match runtime values. Same pattern as
+    // dispatchReviewer; this dispatcher was missing the projection so all
+    // three string fields came through as null and crashed at `.replace()`.
+    `repos/ora-ui/ora-ui/pulls/${prNumber} --jq '{number, title, body, headRefName: .head.ref, baseRefName: .base.ref, headSha: .head.sha}'`
   );
 
   // Falls back to the PR number itself — not ideal but avoids leaving a blank.


### PR DESCRIPTION
## Summary

`dispatchAddressReview` requested `headRefName` / `baseRefName` / `headSha` directly from the REST API response shape via jq, but those fields are nested as `.head.ref`, `.base.ref`, `.head.sha` in REST. All three came through as `null`, crashing at `branch.replace(...)` the moment v2 tried to dispatch an address-review implementer:

```
TypeError: Cannot read properties of null (reading 'replace')
    at dispatchAddressReview (.sandcastle/main.v2.mts:792:46)
```

Same projection pattern as `dispatchReviewer` (fixed in #228 for that codepath; this one was missed). Address-review hadn't been exercised in v2-lane since slice #224 landed, which is why the bug only surfaced now on the #236 review loop.

## Test plan

- [ ] Re-dispatch v2 on #236 after merge; verify address-review implementer spawns successfully and applies the reviewer's feedback (escalate-to-human filter + trailing newlines).
- [ ] Sanity: confirm `dispatchReviewer` projection is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)