### PR TITLE
fix(sandcastle): whitespace-tolerant promise regex for reviewer

### DIFF
--- a/.sandcastle/main.v2.mts
+++ b/.sandcastle/main.v2.mts
@@ -721,9 +721,19 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
   }
   const transcript = result.stdout + '\n' + logContents;
 
-  const approveMatch = transcript.match(/<promise>agent:review:approve<\/promise>/);
-  const requestChangesMatch = transcript.match(/<promise>agent:review:request-changes<\/promise>/);
-  const escalateMatch = transcript.match(/<promise>agent:review:escalate<\/promise>/);
+  // Whitespace-tolerant matching: agents occasionally emit the promise tag
+  // across multiple lines (e.g. `<promise>agent:review:\n  approve</promise>`)
+  // or with stray padding. \s* between every segment absorbs those without
+  // matching unrelated content.
+  const approveMatch = transcript.match(
+    /<promise>\s*agent\s*:\s*review\s*:\s*approve\s*<\/promise>/
+  );
+  const requestChangesMatch = transcript.match(
+    /<promise>\s*agent\s*:\s*review\s*:\s*request-changes\s*<\/promise>/
+  );
+  const escalateMatch = transcript.match(
+    /<promise>\s*agent\s*:\s*review\s*:\s*escalate\s*<\/promise>/
+  );
 
   const issueNumber = extractClosingIssue(prData.body);
 


### PR DESCRIPTION
## Summary

The reviewer agent occasionally emits its promise tag across multiple lines:

```
<promise>agent:review:
approve</promise>
```

The previous exact-match regex required the entire tag content on a single line with no whitespace, so the orchestrator reported "no recognizable promise" and exited 1 even though the agent had cleanly produced a review summary and posted the comment-state review.

Relax all three outcome regexes with `\s*` between each segment of the tag content. The regex still requires the exact tag shape (`<promise>` open + `</promise>` close) and exact outcome strings (`approve`, `request-changes`, `escalate`); only inter-segment whitespace is tolerated.

## Test plan

- [ ] Re-dispatch reviewer on a draft PR (e.g. the open one referencing the v2 workflows issue) and verify the orchestrator now recognises the promise and applies the correct label transition.
- [ ] Confirm none of the three outcome regexes match unrelated content (`<promise>agent:something:approve</promise>` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)