### PR TITLE
fix(workflows): stub empty .sandcastle/.env before invoking orchestrator

### DIFF
--- a/.github/workflows/sandcastle-v2-impl.yml
+++ b/.github/workflows/sandcastle-v2-impl.yml
@@ -26,6 +26,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # `pnpm sandcastle` invokes `tsx --env-file=.sandcastle/.env`, which
+      # errors on a missing file. The file is gitignored (local secrets);
+      # in CI all env vars come from the workflow env block, so an empty
+      # file is sufficient to satisfy Node. Follow-up: switch to
+      # `--env-file-if-exists` once CI Node bumps to 22+.
+      - name: Stub .sandcastle/.env for tsx --env-file
+        run: touch .sandcastle/.env
+
       - name: Run impl dispatch
         env:
           GH_TOKEN: ${{ secrets.SANDCASTLE_BOT_TOKEN }}

--- a/.github/workflows/sandcastle-v2-review.yml
+++ b/.github/workflows/sandcastle-v2-review.yml
@@ -29,6 +29,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # `pnpm sandcastle` invokes `tsx --env-file=.sandcastle/.env`, which
+      # errors on a missing file. The file is gitignored (local secrets);
+      # in CI all env vars come from the workflow env block, so an empty
+      # file is sufficient to satisfy Node. Follow-up: switch to
+      # `--env-file-if-exists` once CI Node bumps to 22+.
+      - name: Stub .sandcastle/.env for tsx --env-file
+        run: touch .sandcastle/.env
+
       - name: Run review dispatch
         env:
           GH_TOKEN: ${{ secrets.SANDCASTLE_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

\`pnpm sandcastle\` invokes \`tsx --env-file=.sandcastle/.env\`, but that file is gitignored (it carries local-only secrets) so it doesn't exist on the runner. Node's \`--env-file\` errors out on missing files:

\`\`\`
node: .sandcastle/.env: not found
ELIFECYCLE  Command failed with exit code 9.
\`\`\`

All env vars in CI come from the workflow's \`env:\` block — the dotenv file just needs to *exist* for Node not to crash. \`touch .sandcastle/.env\` before each invocation does the trick.

Follow-up: switch \`--env-file\` to \`--env-file-if-exists\` once CI Node bumps to 22+, then remove the \`touch\` step.

## Test plan

- [ ] After merge, fire \`sandcastle-v2-impl.yml\` from the Actions UI; verify it gets past the env-file error and into the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)