### PR TITLE
fix(workflows): build sandcastle Docker image before invoking orchestrator

### DIFF
--- a/.github/workflows/sandcastle-v2-impl.yml
+++ b/.github/workflows/sandcastle-v2-impl.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Stub .sandcastle/.env for tsx --env-file
         run: touch .sandcastle/.env
 
+      # Sandcastle resolves the image name from the repo directory name
+      # (defaultImageName in @ai-hero/sandcastle/mountUtils) — for this repo
+      # that is `sandcastle:ora-ui`. Locally the image is cached after the
+      # first build; in CI we rebuild each run. Cache optimization deferred.
+      - name: Build sandcastle Docker image
+        run: docker build -t sandcastle:ora-ui -f .sandcastle/Dockerfile .sandcastle
+
       - name: Run impl dispatch
         env:
           GH_TOKEN: ${{ secrets.SANDCASTLE_BOT_TOKEN }}

--- a/.github/workflows/sandcastle-v2-review.yml
+++ b/.github/workflows/sandcastle-v2-review.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Stub .sandcastle/.env for tsx --env-file
         run: touch .sandcastle/.env
 
+      # Sandcastle resolves the image name from the repo directory name
+      # (defaultImageName in @ai-hero/sandcastle/mountUtils) — for this repo
+      # that is `sandcastle:ora-ui`. Locally the image is cached after the
+      # first build; in CI we rebuild each run. Cache optimization deferred.
+      - name: Build sandcastle Docker image
+        run: docker build -t sandcastle:ora-ui -f .sandcastle/Dockerfile .sandcastle
+
       - name: Run review dispatch
         env:
           GH_TOKEN: ${{ secrets.SANDCASTLE_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

CI was failing inside the dispatch step with:

\`\`\`
WorktreeError: Provider 'docker' create failed:
docker run failed: Unable to find image 'sandcastle:ora-ui' locally
docker: Error response from daemon: pull access denied for sandcastle...
\`\`\`

The sandcastle library derives the image name from the repo directory name (\`defaultImageName\` in \`@ai-hero/sandcastle/mountUtils\`) — for this repo that resolves to \`sandcastle:ora-ui\`. Locally it's cached after the first build; the CI runner has no cache.

Add a \`docker build -t sandcastle:ora-ui -f .sandcastle/Dockerfile .sandcastle\` step to both workflows before the orchestrator invocation.

## Cost note

Each CI run pays the full image build (~2-5 min: apt update, gh CLI install, pnpm + agent CLIs install). For 12-hourly cron sweeps this is acceptable. Follow-up: GHA build-push-action with registry-backed layer cache, or pre-publish the image to GHCR and just \`docker pull\` here.

## Test plan

- [ ] After merge, fire \`sandcastle-v2-impl.yml\`; verify the build step completes and the orchestrator reaches the agent dispatch without the missing-image error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)