### PR TITLE
fix(sandcastle): harden prompts for claude-code provider compat

### DIFF
--- a/.sandcastle/implement-address-review.md
+++ b/.sandcastle/implement-address-review.md
@@ -11,6 +11,20 @@ flip the label back to `agent-review-pending`.
 You never expand scope beyond what the reviewer asked for, and you never
 touch files outside the original PR's diff. Violating this → BLOCKED.
 
+## Definition of done
+
+Your task is **not complete** until all of the following have happened in
+your shell session:
+
+1. `git commit` produced a new `sandcastle-` commit.
+2. `git push --force` succeeded.
+3. `gh pr edit ... --remove-label agent-impl-todo --add-label agent-review-pending` succeeded.
+
+Edits alone are **not** completion. If you stop after editing files
+without running the shell sequence below, the orchestrator considers
+the run failed and the work is wasted. Run the commands. Do not narrate
+what you would do — execute them.
+
 ## PR directive
 
 Work on **PR #{{PR_NUMBER}}**. Do not pick a different PR.
@@ -78,31 +92,29 @@ Then output `<working-on-pr>{{PR_NUMBER}}</working-on-pr>` on its own line.
    before commit. If a gate fails and you cannot fix it after a genuine
    attempt, stop with BLOCKED.
 
-6. **Commit** — single commit. Message MUST start with `sandcastle-` and
-   include `Closes #{{ISSUE_REF}}` in the body so the `Closes #N` line
-   auto-closes the referenced issue on merge:
+6. **Land the changes — mandatory shell sequence.** After gates are
+   green, run the following commands **in order, in your shell**. Do
+   not skip, reorder, or replace these with narration. This block is
+   the only way the orchestrator sees your work:
 
-   ```
-   git add -A && git commit -m "sandcastle-fix(scope): address review comments
+   ```bash
+   # Commit (MUST start with sandcastle- and include Closes #N)
+   git add -A && git commit -m "sandcastle-fix(<scope>): address review comments
 
    - address reviewer comment: <short description>
    Closes #{{ISSUE_REF}}"
-   ```
 
-   `<short description>` should be a 1–3 word summary of the change.
-
-7. **Push** — force-push the current branch to the origin:
-
-   ```
+   # Force-push (the branch already exists upstream)
    git push origin "$(git branch --show-current)" --force
-   ```
 
-8. **Label flip** — apply `agent-review-pending` to the PR so the reviewer
-   picks it up on the next sweep:
-
-   ```
+   # Flip the label so the reviewer picks the PR up next sweep
    gh pr edit {{PR_NUMBER}} --remove-label agent-impl-todo --add-label agent-review-pending
    ```
+
+   If any command fails, stop and emit BLOCKED with the failing output.
+   Do not proceed past a failed step.
+
+   `<short description>` should be a 1–3 word summary of the change.
 
 ## Scope guard (mandatory)
 

--- a/.sandcastle/implement-fresh.md
+++ b/.sandcastle/implement-fresh.md
@@ -8,6 +8,22 @@ You are running in **fresh implementer mode** under the v2 orchestrator
 a draft PR, then stop. You never edit existing branches and never address
 review comments — a separate agent owns that path.
 
+## Definition of done
+
+Your task is **not complete** until all of the following have happened in
+your shell session:
+
+1. `git commit` produced a `sandcastle-` commit.
+2. `git push` succeeded.
+3. `gh pr create --draft` returned a PR URL.
+4. `gh pr edit ... --add-label agent-review-pending` succeeded.
+5. You emitted `<pr-number>N</pr-number>` with the integer PR number.
+
+Edits alone are **not** completion. If you stop after editing files
+without running the shell sequence below, the orchestrator considers
+the run failed and the work is wasted. Run the commands. Do not narrate
+what you would do — execute them.
+
 ## Issue directive
 
 Work on issue **#{{ISSUE_NUMBER}}**. Do not pick a different issue and
@@ -48,38 +64,42 @@ its own line.
    attempt, stop with BLOCKED — never emit COMPLETE without a green
    committed build. Do not rationalize a failing gate as
    "environment-related" — emit BLOCKED with the failing output.
-5. **Commit** — single commit, format per shared protocol.
-6. **Push** — push the current branch:
+5. **Land the PR — mandatory shell sequence.** After gates are green,
+   run the following commands **in order, in your shell**. Do not skip,
+   reorder, or replace these with narration. This block is the only way
+   the orchestrator sees your work:
 
-   ```
+   ```bash
+   # Commit (format per shared protocol)
+   git add -A && git commit -m "sandcastle-<type>(<scope>): <short description>
+
+   <body if needed>
+
+   Closes #{{ISSUE_NUMBER}}"
+
+   # Push
    git push -u origin "$(git branch --show-current)"
-   ```
 
-7. **Open draft PR** — open a draft PR against `develop` and capture
-   its number. The PR body must include `Closes #{{ISSUE_NUMBER}}` so
-   merge auto-closes the issue.
-
-   ```
+   # Open draft PR
    gh pr create --draft --base develop \
      --head "$(git branch --show-current)" \
-     --title "agent:type(scope): short description" \
+     --title "agent:<type>(<scope>): <short description>" \
      --body "$(cat <<'EOF'
    <pr-summary content here>
 
    Closes #{{ISSUE_NUMBER}}
    EOF
    )"
+
+   # Capture the PR number
+   PR_NUMBER=$(gh pr view --json number --jq .number)
+
+   # Apply review-pending label
+   gh pr edit "$PR_NUMBER" --add-label agent-review-pending
    ```
 
-   Capture the PR number from the URL `gh pr create` prints
-   (`.../pull/<N>`), or run `gh pr view --json number --jq .number`.
-
-8. **Label** — apply `agent-review-pending` to the PR so the orchestrator
-   picks it up for review on the next sweep:
-
-   ```
-   gh pr edit <PR_NUMBER> --add-label agent-review-pending
-   ```
+   If any command fails, stop and emit BLOCKED with the failing output.
+   Do not proceed past a failed step.
 
 ## Scope ceiling
 
@@ -106,18 +126,16 @@ reviewer cannot safely vet runs larger than this.
 
 # Done
 
-Before declaring COMPLETE, verify all of these:
+Run these verification commands in your shell. If any fails, you have
+not landed the work — emit BLOCKED with the failing output. Do not
+emit `<pr-number>` or COMPLETE in that case.
 
-```
+```bash
 git branch --show-current          # must equal the branch you started on
 git log --oneline --grep="^sandcastle-" -1   # must show your commit
 git rev-parse @{u}                  # must succeed (branch pushed)
 gh pr view --json number,isDraft    # must show isDraft: true
 ```
-
-If any check fails, you have not landed the work the orchestrator
-expects — output BLOCKED per shared protocol with the failing output
-included.
 
 Otherwise, output the PR number, summary, and completion signal in one
 final message (do not split across messages):

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -14,6 +14,20 @@ based on the promise tag you emit. Never call `gh pr edit --add-label` or
 `--remove-label`. If you do, the label state becomes inconsistent and the
 next orchestrator sweep will re-spawn this reviewer in a loop.
 
+## Definition of done
+
+Your task is **not complete** until both of these have happened in your
+shell session:
+
+1. You executed the `gh pr review` (and, for request-changes, `gh api`)
+   command(s) under your chosen option, and they returned successfully.
+2. You emitted the `<promise>` tag for that option exactly once.
+
+Emitting only the promise tag without running the posting commands
+leaves the PR with no visible review, the orchestrator cannot tell the
+reviewer ran, and the run is wasted. Execute the commands. Do not
+narrate what you would do — run them.
+
 ## Context
 
 ### PR metadata


### PR DESCRIPTION
## Summary

- Adds a "Definition of done" block to `implement-fresh.md`, `implement-address-review.md`, and `review-prompt.md` so the agent treats the closing shell sequence as terminal work, not optional verification.
- Collapses the commit/push/PR-open/label sequence into one mandatory shell block (was previously split across 3-4 numbered steps).
- Reframes the trailing verification commands as "run these in your shell" rather than a passive checklist.

The claude-code provider tends to stop after file edits and treat shell ops as optional. The pi provider followed the prior numbered checklist fine. New framing makes the shell sequence the explicit terminal action that defines completion.

## Test plan

- [ ] Manually trigger `sandcastle-v2-impl.yml` workflow_dispatch with `SANDCASTLE_IMPL_AGENT=claude-code:claude-sonnet-4-6` against a small `agent-ready` issue. Expect: agent runs commit/push/PR sequence and emits `<pr-number>`.
- [ ] Same on `sandcastle-v2-review.yml` with `SANDCASTLE_REVIEWER_AGENT=claude-code:claude-sonnet-4-6`.
- [ ] Confirm pi-provider runs still pass — no regression from the structural reshuffle.

Refs #248