### PR TITLE
fix(sandcastle): generate fumadocs sources and fix turbo cache in Docker

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -54,6 +54,9 @@ const botGitEnv = {
   GIT_COMMITTER_NAME: BOT_NAME,
   GIT_COMMITTER_EMAIL: BOT_EMAIL,
   GH_TOKEN: process.env.SANDCASTLE_BOT_TOKEN ?? process.env.GH_TOKEN ?? '',
+  // Turbo defaults to a cache path derived from the host cwd at build time,
+  // which resolves to a Mac path that doesn't exist inside the Docker container.
+  TURBO_CACHE_DIR: '/tmp/turbo-cache',
 };
 
 // Token presence check shared by all execute-mode dispatchers. Fail closed

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -702,7 +702,14 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
   const logPath = `.sandcastle/logs/${branch.replace(/\//g, '-')}-reviewer.log`;
 
   const result = await sandcastle.run({
-    hooks: { sandbox: { onSandboxReady: [{ command: 'pnpm install' }] } },
+    hooks: {
+      sandbox: {
+        onSandboxReady: [
+          { command: 'pnpm install' },
+          { command: 'cd apps/www && pnpm exec fumadocs-mdx' },
+        ],
+      },
+    },
     copyToWorktree: ['node_modules'],
     sandbox: docker({ env: botGitEnv }),
     branchStrategy: { type: 'branch', branch, baseBranch: prData.baseRefName },
@@ -824,7 +831,14 @@ async function dispatchAddressReview(prNumber: number): Promise<void> {
   const logPath = `.sandcastle/logs/${branch.replace(/\//g, '-')}-impl-address-review.log`;
 
   const result = await sandcastle.run({
-    hooks: { sandbox: { onSandboxReady: [{ command: 'pnpm install' }] } },
+    hooks: {
+      sandbox: {
+        onSandboxReady: [
+          { command: 'pnpm install' },
+          { command: 'cd apps/www && pnpm exec fumadocs-mdx' },
+        ],
+      },
+    },
     copyToWorktree: ['node_modules'],
     sandbox: docker({ env: botGitEnv }),
     branchStrategy: { type: 'branch', branch, baseBranch: prData.baseRefName },
@@ -872,7 +886,14 @@ async function dispatchFreshImplementer(issueNumber: number): Promise<void> {
   const logPath = `.sandcastle/logs/${branch.replace(/\//g, '-')}-impl-fresh.log`;
 
   const result = await sandcastle.run({
-    hooks: { sandbox: { onSandboxReady: [{ command: 'pnpm install' }] } },
+    hooks: {
+      sandbox: {
+        onSandboxReady: [
+          { command: 'pnpm install' },
+          { command: 'cd apps/www && pnpm exec fumadocs-mdx' },
+        ],
+      },
+    },
     copyToWorktree: ['node_modules'],
     sandbox: docker({ env: botGitEnv }),
     branchStrategy: { type: 'branch', branch, baseBranch: BASE_BRANCH },


### PR DESCRIPTION
## Summary

- Adds `cd apps/www && pnpm exec fumadocs-mdx` as a second `onSandboxReady` hook step across all three dispatchers (fresh implementer, reviewer, address-review). The fumadocs-mdx plugin generates the `.source/` directory that TypeScript needs to resolve the `collections/*` path alias — without it `pnpm typecheck` fails on every agent run.
- Sets `TURBO_CACHE_DIR=/tmp/turbo-cache` in `botGitEnv` so turbo doesn't try to write to the host Mac path that doesn't exist inside the Docker container.

## Context

Surfaced when the agent dispatched for #251 emitted BLOCKED because `pnpm typecheck` failed. Both issues are environmental — pre-existing in the workspace, unrelated to the issue being worked — and were confirmed by running typecheck on the baseline branch before any changes.