### PR TITLE
fix(sandcastle): run fumadocs-mdx sequentially after pnpm install

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -707,7 +707,7 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
   const result = await sandcastle.run({
     hooks: {
       sandbox: {
-        onSandboxReady: [{ command: 'pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)' }],
+        onSandboxReady: [{ command: 'pnpm install' }],
       },
     },
     copyToWorktree: ['node_modules'],
@@ -833,7 +833,7 @@ async function dispatchAddressReview(prNumber: number): Promise<void> {
   const result = await sandcastle.run({
     hooks: {
       sandbox: {
-        onSandboxReady: [{ command: 'pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)' }],
+        onSandboxReady: [{ command: 'pnpm install' }],
       },
     },
     copyToWorktree: ['node_modules'],
@@ -885,7 +885,7 @@ async function dispatchFreshImplementer(issueNumber: number): Promise<void> {
   const result = await sandcastle.run({
     hooks: {
       sandbox: {
-        onSandboxReady: [{ command: 'pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)' }],
+        onSandboxReady: [{ command: 'pnpm install' }],
       },
     },
     copyToWorktree: ['node_modules'],

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -707,10 +707,7 @@ async function dispatchReviewer(prNumber: number): Promise<void> {
   const result = await sandcastle.run({
     hooks: {
       sandbox: {
-        onSandboxReady: [
-          { command: 'pnpm install' },
-          { command: 'cd apps/www && pnpm exec fumadocs-mdx' },
-        ],
+        onSandboxReady: [{ command: 'pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)' }],
       },
     },
     copyToWorktree: ['node_modules'],
@@ -836,10 +833,7 @@ async function dispatchAddressReview(prNumber: number): Promise<void> {
   const result = await sandcastle.run({
     hooks: {
       sandbox: {
-        onSandboxReady: [
-          { command: 'pnpm install' },
-          { command: 'cd apps/www && pnpm exec fumadocs-mdx' },
-        ],
+        onSandboxReady: [{ command: 'pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)' }],
       },
     },
     copyToWorktree: ['node_modules'],
@@ -891,10 +885,7 @@ async function dispatchFreshImplementer(issueNumber: number): Promise<void> {
   const result = await sandcastle.run({
     hooks: {
       sandbox: {
-        onSandboxReady: [
-          { command: 'pnpm install' },
-          { command: 'cd apps/www && pnpm exec fumadocs-mdx' },
-        ],
+        onSandboxReady: [{ command: 'pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)' }],
       },
     },
     copyToWorktree: ['node_modules'],

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -12,7 +12,7 @@
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:watch": "vitest",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "fumadocs-mdx && tsc --noEmit",
     "scaffold": "plop --plopfile scripts/plopfile.mjs",
     "gen:registry": "tsx scripts/gen-registry.cli.ts",
     "gen:registry:check": "tsx scripts/gen-registry.cli.ts --check",


### PR DESCRIPTION
## Summary

- Combines the two `onSandboxReady` hook commands into one (`pnpm install && (cd apps/www && pnpm exec fumadocs-mdx)`) across all three dispatchers. The sandcastle SDK runs hook array entries in parallel — so the previous two-entry array was firing `fumadocs-mdx` before `pnpm install` finished, causing it to hang on missing node_modules and hit the 60s timeout.

## Context

Surfaced immediately on the first live dispatch after #252 merged. The timeout error was `HookTimeoutError: Hook 'cd apps/www && pnpm exec fumadocs-mdx' timed out after 60000ms`.