### PR TITLE
docs(context): add Semantic layer and Scale glossary entries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -171,3 +171,28 @@ One special entry exists outside `registry/ui/`:
 
 Token/theme distribution is documented, not enforced via registryDependencies,
 to allow incremental adoption without requiring consumers to adopt Ora's token system.
+
+### Semantic layer
+
+The middle tier of Ora's three-tier token architecture ([[Scale]] →
+Semantic layer → component vars). A small, fixed-shape set of named
+roles — backgrounds, surfaces, ui strengths, solids, borders, ring,
+foregrounds — that components actually read. Components never reach
+into the Scale directly; they read semantic roles, and the roles map
+onto Scale steps. A theme reimplements this layer to swap aesthetics
+while the role names and their intent stay constant.
+
+See `docs/conventions/TOKEN-SYSTEM.md` for the full role list and
+naming convention.
+
+### Scale
+
+The palette tier of the three-tier token architecture — raw step
+values per hue (e.g. `--gray-*`, `--accent-*`). Pure values, no
+intent. A theme is a Scale implementation: it supplies the step values
+that the [[Semantic layer]] maps onto. New themes plug in by providing
+Scale values for the same set of roles rather than forking the
+component set.
+
+See `docs/conventions/TOKEN-SYSTEM.md` for how Scales back the
+semantic roles.


### PR DESCRIPTION
## What

Adds two glossary entries to `CONTEXT.md` — **Semantic layer** and **Scale** — the contributor-facing terms introduced by [ADR-0008](docs/adr/0008-interim-role-layer-for-tokens.md)'s three-tier token model.

- **Semantic layer** — names the three tiers (scale → semantic layer → component vars), describes it as the role set components read and themes reimplement.
- **Scale** — defines the palette tier (raw step values per hue), notes a theme *is* a Scale implementation.

Both are glossary-shaped: short paragraph, cross-linked via `[[ ]]`, deferring the full reference to `TOKEN-SYSTEM.md` rather than restating it. Style/length match the existing Slice / Manifest / Index entries.

## Acceptance criteria

- [x] `Semantic layer` entry names the three tiers and links to `TOKEN-SYSTEM.md`
- [x] `Scale` entry defines the palette layer and notes its role in theme implementations
- [x] Both match existing CONTEXT.md style and length norms
- [x] No duplication of full reference content — entries are glossary-shaped

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)