### PR TITLE
feat(theme): add 18-token semantic layer to globals.css (additive)

### DIFF
--- a/apps/www/app/app.css
+++ b/apps/www/app/app.css
@@ -1,4 +1,7 @@
 :root {
   --sidebar-width: 16rem;
   --sidebar-padding-block: 32px;
+  --header-height: 48px;
+  --breakpoint-max-layout-width: 89rem;
+  --root-layout-padding: 3rem;
 }

--- a/apps/www/registry/theme/colors.css
+++ b/apps/www/registry/theme/colors.css
@@ -1,5 +1,4 @@
 :root {
-  --gray-base: oklch(1 0 0); /* radix-step-1 */
   --gray-50: oklch(0.982 0 0); /* radix-step-2 */
   --gray-100: oklch(0.955 0 0); /* radix-step-3 */
   --gray-200: oklch(0.931 0 0); /* radix-step-4 */
@@ -122,7 +121,6 @@
 }
 
 .dark {
-  --gray-base: oklch(0.178 0 0);
   --gray-50: oklch(0.213 0 0);
   --gray-100: oklch(0.256 0 0);
   --gray-200: oklch(0.285 0 0);

--- a/apps/www/registry/theme/globals.css
+++ b/apps/www/registry/theme/globals.css
@@ -45,6 +45,39 @@
   --on-fill: var(--gray-on-fill);
   --ui-label: var(--primary);
 
+  /* ------------------------------------------------
+     Semantic layer (ADR-0008) — 18-token contract.
+     Additive: legacy tokens (--surface, --hover, --active,
+     --fill, --line-ui …) stay in place; the layer below is
+     what ported components read. Default (gray) values live
+     on --gray-* role tokens; themed palettes override via
+     [data-theme] reading their own --<palette>-* tokens.
+     Bare aliases (--border, --interactive) map to step 1.
+     ------------------------------------------------ */
+  /* Surfaces — --background, --surface-1, --surface-2, --overlay defined above */
+  --subtle: var(--gray-surface); /* solid, subtler than --background */
+  /* UI — soft interactive container (single) */
+  --ui: var(--gray-ui);
+  /* Interactive — container interaction states, ordinal strength */
+  --interactive-1: var(--gray-interactive-1);
+  --interactive-2: var(--gray-interactive-2);
+  --interactive: var(--interactive-1);
+  /* Solid — emphatic fill + its interaction state */
+  --solid: var(--gray-fill);
+  --solid-interactive: var(--gray-solid-interactive);
+  /* Borders — separator (solid, above) + alpha ui borders */
+  --border-1: var(--gray-line-ui);
+  --border-2: var(--gray-border-2);
+  --border: var(--border-1);
+  /* Foreground — --primary, --secondary, --ui-label defined above */
+  --on-solid: var(--gray-on-fill);
+
+  /* gray role tokens for the new semantic slots */
+  --gray-interactive-1: oklch(0 0 0 / 0.055);
+  --gray-interactive-2: oklch(0 0 0 / 0.08);
+  --gray-solid-interactive: color-mix(in oklab, var(--gray-950), var(--gray-900));
+  --gray-border-2: oklch(0 0 0 / 0.153);
+
   --gray-background: oklch(1 0 0);
   --gray-surface: oklch(0.982 0 0);
   --gray-overlay: oklch(1 0 0);
@@ -77,6 +110,8 @@
   --accent-secondary: oklch(0.556 0.162 252.2);
   --accent-primary: oklch(0.324 0.096 258.8);
   --accent-on-fill: white;
+  --accent-solid-interactive: oklch(0.622 0.183 251.7); /* blue-800 */
+  --accent-border-2: oklch(0.564 0.204 257.51 / 0.569); /* blue-a600 */
 
   --success-ui: oklch(0.631 0.212 142.843 / 0.09);
   --success-fill: oklch(0.651 0.147 147.392);
@@ -89,6 +124,8 @@
   --success-secondary: oklch(0.526 0.13 147.36);
   --success-primary: oklch(0.327 0.054 146.815);
   --success-on-fill: white;
+  --success-solid-interactive: oklch(0.612 0.141 147.431); /* green-800 */
+  --success-border-2: oklch(0.55 0.181 143.51 / 0.596); /* green-a600 */
 
   --warning-ui: oklch(0.879 0.18 93.577 / 0.247);
   --warning-fill: oklch(0.867 0.176 90.669);
@@ -101,6 +138,8 @@
   --warning-secondary: oklch(0.572 0.117 86.53);
   --warning-primary: oklch(0.352 0.045 90.33);
   --warning-on-fill: black;
+  --warning-solid-interactive: oklch(0.838 0.165 90.363); /* yellow-800 */
+  --warning-border-2: oklch(0.696 0.143 85.473 / 0.773); /* yellow-a600 */
 
   /* destructive palette */
   --destructive-ui: oklch(0.65 0.237 33.432 / 0.106);
@@ -114,6 +153,8 @@
   --destructive-secondary: oklch(0.532 0.199 32.458 / 0.839);
   --destructive-primary: oklch(0.243 0.081 37.215 / 0.867);
   --destructive-on-fill: white;
+  --destructive-solid-interactive: oklch(0.625 0.181 34.021); /* red-800 */
+  --destructive-border-2: oklch(0.577 0.214 32.719 / 0.522); /* red-a600 */
 
   /* --primary-foreground: oklch(0.985 0 0); */
   /* --secondary-foreground: oklch(0.205 0 0); */
@@ -157,6 +198,24 @@
   --disabled: var(--gray-disabled);
   --on-fill: var(--gray-on-fill);
 
+  /* Semantic layer (ADR-0008) — same 18 slots, dark values */
+  --subtle: var(--gray-surface);
+  --ui: var(--gray-ui);
+  --interactive-1: var(--gray-interactive-1);
+  --interactive-2: var(--gray-interactive-2);
+  --interactive: var(--interactive-1);
+  --solid: var(--gray-fill);
+  --solid-interactive: var(--gray-solid-interactive);
+  --border-1: var(--gray-line-ui);
+  --border-2: var(--gray-border-2);
+  --border: var(--border-1);
+  --on-solid: var(--gray-on-fill);
+
+  --gray-interactive-1: oklch(1 0 0 / 0.075);
+  --gray-interactive-2: oklch(1 0 0 / 0.115);
+  --gray-solid-interactive: color-mix(in oklab, var(--gray-950), var(--gray-900));
+  --gray-border-2: oklch(1 0 0 / 0.173);
+
   --gray-background: oklch(0.105 0 0);
   --gray-surface: oklch(0.145 0 0);
   --gray-overlay: oklch(0.178 0 0);
@@ -187,6 +246,8 @@
   --accent-ring: oklch(0.662 0.184 252.588 / 0.588);
   --accent-secondary: oklch(0.746 0.16 251.5);
   --accent-primary: oklch(0.905 0.048 249.319);
+  --accent-solid-interactive: oklch(0.612 0.19 253.269); /* blue-800 */
+  --accent-border-2: oklch(0.664 0.181 252.459 / 0.725); /* blue-a600 */
 
   --success-ui: oklch(0.894 0.202 145.082 / 0.106);
   --success-fill: oklch(0.651 0.147 147.392);
@@ -199,6 +260,8 @@
   --success-secondary: oklch(0.78 0.143 147.473);
   --success-primary: oklch(0.91 0.077 147.124);
   --success-on-fill: white;
+  --success-solid-interactive: oklch(0.61 0.146 147.408); /* green-800 */
+  --success-border-2: oklch(0.895 0.189 146.676 / 0.439); /* green-a600 */
 
   --warning-ui: oklch(0.804 0.17 74.67 / 0.11);
   --warning-fill: oklch(0.82 0.165 90.325);
@@ -211,6 +274,8 @@
   --warning-secondary: oklch(0.871 0.162 90.498);
   --warning-primary: oklch(0.936 0.067 91.506);
   --warning-on-fill: black;
+  --warning-solid-interactive: oklch(0.787 0.161 89.593); /* yellow-800 */
+  --warning-border-2: oklch(0.877 0.16 90.2 / 0.471); /* yellow-a600 */
 
   --destructive-ui: oklch(0.647 0.238 32.438 / 0.165);
   --destructive-fill: oklch(0.664 0.179 34.086);
@@ -223,6 +288,8 @@
   --destructive-secondary: oklch(0.77 0.138 35.323);
   --destructive-primary: oklch(0.898 0.047 32.8);
   --destructive-on-fill: white;
+  --destructive-solid-interactive: oklch(0.625 0.179 34.149); /* red-800 */
+  --destructive-border-2: oklch(0.708 0.184 33.964 / 0.655); /* red-a600 */
 }
 
 /* ------------------------------------------------
@@ -245,6 +312,18 @@
   --primary: var(--accent-primary);
   --on-fill: var(--accent-on-fill);
   --ui-label: var(--accent-secondary);
+
+  /* semantic layer (ADR-0008) */
+  --ui: var(--accent-ui);
+  --interactive-1: var(--accent-hover);
+  --interactive-2: var(--accent-active);
+  --interactive: var(--interactive-1);
+  --solid: var(--accent-fill);
+  --solid-interactive: var(--accent-solid-interactive);
+  --border-1: var(--accent-line-ui);
+  --border-2: var(--accent-border-2);
+  --border: var(--border-1);
+  --on-solid: var(--accent-on-fill);
 }
 
 [data-theme='destructive'] {
@@ -260,6 +339,18 @@
   --primary: var(--destructive-primary);
   --on-fill: var(--destructive-on-fill);
   --ui-label: var(--destructive-secondary);
+
+  /* semantic layer (ADR-0008) */
+  --ui: var(--destructive-ui);
+  --interactive-1: var(--destructive-hover);
+  --interactive-2: var(--destructive-active);
+  --interactive: var(--interactive-1);
+  --solid: var(--destructive-fill);
+  --solid-interactive: var(--destructive-solid-interactive);
+  --border-1: var(--destructive-line-ui);
+  --border-2: var(--destructive-border-2);
+  --border: var(--border-1);
+  --on-solid: var(--destructive-on-fill);
 }
 
 [data-theme='warning'] {
@@ -275,6 +366,18 @@
   --primary: var(--warning-primary);
   --on-fill: var(--warning-on-fill);
   --ui-label: var(--warning-secondary);
+
+  /* semantic layer (ADR-0008) */
+  --ui: var(--warning-ui);
+  --interactive-1: var(--warning-hover);
+  --interactive-2: var(--warning-active);
+  --interactive: var(--interactive-1);
+  --solid: var(--warning-fill);
+  --solid-interactive: var(--warning-solid-interactive);
+  --border-1: var(--warning-line-ui);
+  --border-2: var(--warning-border-2);
+  --border: var(--border-1);
+  --on-solid: var(--warning-on-fill);
 }
 
 [data-theme='success'] {
@@ -290,6 +393,18 @@
   --primary: var(--success-primary);
   --on-fill: var(--success-on-fill);
   --ui-label: var(--success-secondary);
+
+  /* semantic layer (ADR-0008) */
+  --ui: var(--success-ui);
+  --interactive-1: var(--success-hover);
+  --interactive-2: var(--success-active);
+  --interactive: var(--interactive-1);
+  --solid: var(--success-fill);
+  --solid-interactive: var(--success-solid-interactive);
+  --border-1: var(--success-line-ui);
+  --border-2: var(--success-border-2);
+  --border: var(--border-1);
+  --on-solid: var(--success-on-fill);
 }
 
 @theme inline {
@@ -323,6 +438,20 @@
   --color-disabled: var(--disabled);
   --color-on-fill: var(--on-fill);
   --color-ui-label: var(--ui-label);
+
+  /* semantic layer (ADR-0008) */
+  --color-subtle: var(--subtle);
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-interactive-1: var(--interactive-1);
+  --color-interactive-2: var(--interactive-2);
+  --color-interactive: var(--interactive);
+  --color-solid: var(--solid);
+  --color-solid-interactive: var(--solid-interactive);
+  --color-border-1: var(--border-1);
+  --color-border-2: var(--border-2);
+  --color-border: var(--border);
+  --color-on-solid: var(--on-solid);
 
   --color-gray-background: var(--gray-background);
   --color-gray-surface: var(--gray-surface);

--- a/apps/www/registry/theme/globals.css
+++ b/apps/www/registry/theme/globals.css
@@ -8,403 +8,117 @@
 :root {
   --radius: 0.375rem;
 
-  /* backgrounds */
-  --background: var(--gray-background);
-  --surface: var(--gray-surface);
-  --overlay: var(--gray-overlay);
-  --ui: var(--gray-ui);
-  --fill: var(--gray-fill);
-
-  /* wip: surfaces */
-  --surface-1: oklch(0 0 0 / 0.025);
+  --background: oklch(0.985 0 0);
+  --subtle: var(--gray-50);
+  --surface-1: oklch(0 0 0 / 0.015);
   --surface-2: oklch(0 0 0 / 0.05);
-
-  /* interactive */
-  --hover: var(--gray-hover);
-  --active: var(--gray-active);
-  --focus: var(--gray-focus);
-  --focus-fill: var(--gray-focus-fill);
-
-  /* line/border  - @deprecated, use separator & ring instead */
-  --line: var(--gray-line);
-  --line-subtle: var(--gray-line-subtle);
-  --line-ui: var(--gray-line-ui);
-
-  --separator: var(--gray-separator);
-  --ring: var(--gray-ring);
-
-  /* foreground */
-  --primary: var(--gray-primary);
-  --secondary: var(--gray-secondary);
-  /* may deprectate muted - TBD */
-  --muted: var(--gray-muted);
-  /* not yet pulling value from scale..
-    if deprecating --muted, may assign gray-700
-  */
-  --disabled: var(--gray-disabled);
-  --on-fill: var(--gray-on-fill);
+  --overlay: var(--background);
+  --fill: var(--gray-950); /* deprecated for solid */
+  --solid: var(--gray-950);
+  --solid-interactive: color-mix(in oklab, var(--gray-950), var(--gray-900));
+  --ui-subtle: var(--gray-a50);
+  --ui: var(--gray-a100);
+  --hover: var(--gray-a200); /* deprecating for interactive */
+  --active: var(--gray-a300); /* deprecating for interactive-strong */
+  --interactive-subtle: var(--gray-a100);
+  --interactive: var(--gray-a200);
+  --interactive-strong: var(--gray-a300);
+  --focus: var(--gray-600); /* deprecating for ring */
+  --focus-fill: var(--gray-600); /* deprecating for ring */
+  --line: var(--gray-400); /* deprecating for separator */
+  --line-subtle: var(--gray-a400); /* deprecated for border-subtle */
+  --line-ui: var(--gray-a500); /* deprecated for border */
+  --border-subtle: var(--gray-400);
+  --border: var(--gray-a500);
+  --border-strong: var(--gray-a600);
+  --separator: var(--gray-300);
+  --ring: var(--gray-600);
+  --primary: var(--gray-950);
+  --secondary: var(--gray-900);
+  --muted: var(--gray-900); /* deprecated */
+  --disabled: var(--gray-700); /* deprecated */
+  --on-fill: var(--gray-50); /* deprecated for on-solid */
+  --on-solid: var(--gray-50);
   --ui-label: var(--primary);
-
-  /* ------------------------------------------------
-     Semantic layer (ADR-0008) — 18-token contract.
-     Additive: legacy tokens (--surface, --hover, --active,
-     --fill, --line-ui …) stay in place; the layer below is
-     what ported components read. Default (gray) values live
-     on --gray-* role tokens; themed palettes override via
-     [data-theme] reading their own --<palette>-* tokens.
-     Bare aliases (--border, --interactive) map to step 1.
-     ------------------------------------------------ */
-  /* Surfaces — --background, --surface-1, --surface-2, --overlay defined above */
-  --subtle: var(--gray-surface); /* solid, subtler than --background */
-  /* UI — soft interactive container (single) */
-  --ui: var(--gray-ui);
-  /* Interactive — container interaction states, ordinal strength */
-  --interactive-1: var(--gray-interactive-1);
-  --interactive-2: var(--gray-interactive-2);
-  --interactive: var(--interactive-1);
-  /* Solid — emphatic fill + its interaction state */
-  --solid: var(--gray-fill);
-  --solid-interactive: var(--gray-solid-interactive);
-  /* Borders — separator (solid, above) + alpha ui borders */
-  --border-1: var(--gray-line-ui);
-  --border-2: var(--gray-border-2);
-  --border: var(--border-1);
-  /* Foreground — --primary, --secondary, --ui-label defined above */
-  --on-solid: var(--gray-on-fill);
-
-  /* gray role tokens for the new semantic slots */
-  --gray-interactive-1: oklch(0 0 0 / 0.055);
-  --gray-interactive-2: oklch(0 0 0 / 0.08);
-  --gray-solid-interactive: color-mix(in oklab, var(--gray-950), var(--gray-900));
-  --gray-border-2: oklch(0 0 0 / 0.153);
-
-  --gray-background: oklch(1 0 0);
-  --gray-surface: oklch(0.982 0 0);
-  --gray-overlay: oklch(1 0 0);
-  --gray-ui: oklch(0 0 0 / 0.035);
-  --gray-fill: oklch(0.244 0 0);
-  --gray-hover: oklch(0 0 0 / 0.055);
-  --gray-active: oklch(0 0 0 / 0.08);
-  --gray-focus: oklch(0.792 0 0);
-  --gray-focus-fill: oklch(0.61 0 0);
-  --gray-line: oklch(0.925 0 0);
-  --gray-line-subtle: oklch(0.945 0 0);
-  --gray-line-ui: oklch(0 0 0 / 0.112);
-  --gray-separator: oklch(0.885 0 0);
-  --gray-ring: oklch(0 0 0 / 0.192);
-  --gray-primary: oklch(0.244 0 0);
-  --gray-secondary: oklch(0.556 0 0);
-  /* may deprectate muted - TBD */
-  --gray-muted: oklch(0.556 0 0);
-  --gray-disabled: oklch(0.7 0 0);
-  --gray-on-fill: oklch(0.982 0 0);
-
-  --accent-ui: oklch(0.597 0.221 258.03 / 0.227);
-  --accent-fill: oklch(0.649 0.193 251.8);
-  --accent-hover: oklch(0.63 0.203 254.355 / 0.149);
-  --accent-active: oklch(0.615 0.211 256.099 / 0.22);
-  --accent-focus: oklch(0.735 0.121 243);
-  --accent-focus-fill: oklch(0.622 0.183 251.7);
-  --accent-line-ui: oklch(0.552 0.206 251 / 0.393);
-  --accent-ring: oklch(0.574 0.211 257.838 / 0.408);
-  --accent-secondary: oklch(0.556 0.162 252.2);
-  --accent-primary: oklch(0.324 0.096 258.8);
-  --accent-on-fill: white;
-  --accent-solid-interactive: oklch(0.622 0.183 251.7); /* blue-800 */
-  --accent-border-2: oklch(0.564 0.204 257.51 / 0.569); /* blue-a600 */
-
-  --success-ui: oklch(0.631 0.212 142.843 / 0.09);
-  --success-fill: oklch(0.651 0.147 147.392);
-  --success-hover: oklch(0.589 0.199 142.742 / 0.145);
-  --success-active: oklch(0.592 0.198 143 / 0.216);
-  --success-focus: oklch(0.716 0.129 147.413);
-  --success-focus-fill: oklch(0.612 0.141 147.431);
-  --success-line-ui: oklch(0.552 0.184 143.139 / 0.42);
-  --success-ring: oklch(0.552 0.184 143.139 / 0.42);
-  --success-secondary: oklch(0.526 0.13 147.36);
-  --success-primary: oklch(0.327 0.054 146.815);
-  --success-on-fill: white;
-  --success-solid-interactive: oklch(0.612 0.141 147.431); /* green-800 */
-  --success-border-2: oklch(0.55 0.181 143.51 / 0.596); /* green-a600 */
-
-  --warning-ui: oklch(0.879 0.18 93.577 / 0.247);
-  --warning-fill: oklch(0.867 0.176 90.669);
-  --warning-hover: oklch(0.865 0.177 90.382 / 0.392);
-  --warning-active: oklch(0.856 0.175 88.008 / 0.529);
-  --warning-focus: oklch(0.761 0.135 90.498);
-  --warning-focus-fill: oklch(0.838 0.165 90.363);
-  --warning-line-ui: oklch(0.724 0.149 83.651 / 0.596);
-  --warning-ring: oklch(0.724 0.149 83.651 / 0.596);
-  --warning-secondary: oklch(0.572 0.117 86.53);
-  --warning-primary: oklch(0.352 0.045 90.33);
-  --warning-on-fill: black;
-  --warning-solid-interactive: oklch(0.838 0.165 90.363); /* yellow-800 */
-  --warning-border-2: oklch(0.696 0.143 85.473 / 0.773); /* yellow-a600 */
-
-  /* destructive palette */
-  --destructive-ui: oklch(0.65 0.237 33.432 / 0.106);
-  --destructive-fill: oklch(0.664 0.179 34.086);
-  --destructive-hover: oklch(0.65 0.237 33.432 / 0.106);
-  --destructive-active: oklch(0.651 0.237 33.578 / 0.278);
-  --destructive-focus: oklch(0.744 0.117 34.256);
-  --destructive-focus-fill: oklch(0.625 0.181 34.021);
-  --destructive-line-ui: oklch(0.802 0.095 32.2 / 0.7);
-  --destructive-ring: oklch(0.609 0.227 32.494 / 0.416);
-  --destructive-secondary: oklch(0.532 0.199 32.458 / 0.839);
-  --destructive-primary: oklch(0.243 0.081 37.215 / 0.867);
-  --destructive-on-fill: white;
-  --destructive-solid-interactive: oklch(0.625 0.181 34.021); /* red-800 */
-  --destructive-border-2: oklch(0.577 0.214 32.719 / 0.522); /* red-a600 */
-
-  /* --primary-foreground: oklch(0.985 0 0); */
-  /* --secondary-foreground: oklch(0.205 0 0); */
-  /* --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325); */
-
-  /* app */
-  --header-height: 48px;
-  --breakpoint-max-layout-width: 89rem;
-  --root-layout-padding: 3rem;
 }
 
 .dark {
-  --background: var(--gray-background);
-  --surface: var(--gray-surface);
-  --overlay: var(--gray-overlay);
-  --ui: var(--gray-ui);
-  --fill: var(--gray-fill);
-
-  /* wip: surfaces */
-  --surface-1: oklch(1 0 0 / 0.05);
+  --background: oklch(0.145 0 0);
+  --overlay: var(--gray-50);
+  --surface-1: oklch(1 0 0 / 0.015);
   --surface-2: oklch(1 0 0 / 0.09);
-
-  --hover: var(--gray-hover);
-  --active: var(--gray-active);
-  --focus: var(--gray-focus);
-  --focus-fill: var(--gray-focus-fill);
-
-  --line: var(--gray-line);
-  --line-subtle: var(--gray-line-subtle);
-  --line-ui: var(--gray-line-ui);
-
-  --separator: var(--gray-separator);
-  --ring: var(--gray-ring);
-
-  --primary: var(--gray-primary);
-  --secondary: var(--gray-secondary);
-  --muted: var(--gray-muted);
-  --disabled: var(--gray-disabled);
-  --on-fill: var(--gray-on-fill);
-
-  /* Semantic layer (ADR-0008) — same 18 slots, dark values */
-  --subtle: var(--gray-surface);
-  --ui: var(--gray-ui);
-  --interactive-1: var(--gray-interactive-1);
-  --interactive-2: var(--gray-interactive-2);
-  --interactive: var(--interactive-1);
-  --solid: var(--gray-fill);
-  --solid-interactive: var(--gray-solid-interactive);
-  --border-1: var(--gray-line-ui);
-  --border-2: var(--gray-border-2);
-  --border: var(--border-1);
-  --on-solid: var(--gray-on-fill);
-
-  --gray-interactive-1: oklch(1 0 0 / 0.075);
-  --gray-interactive-2: oklch(1 0 0 / 0.115);
-  --gray-solid-interactive: color-mix(in oklab, var(--gray-950), var(--gray-900));
-  --gray-border-2: oklch(1 0 0 / 0.173);
-
-  --gray-background: oklch(0.105 0 0);
-  --gray-surface: oklch(0.145 0 0);
-  --gray-overlay: oklch(0.178 0 0);
-  --gray-ui: oklch(1 0 0 / 0.05);
-  --gray-fill: oklch(0.949 0 0);
-  --gray-hover: oklch(1 0 0 / 0.075);
-  --gray-active: oklch(1 0 0 / 0.115);
-  --gray-focus: oklch(0.489 0 0);
-  --gray-focus-fill: oklch(0.586 0 0);
-  --gray-line: oklch(0.258 0 0);
-  --gray-line-subtle: oklch(0.21 0 0);
-  --gray-line-ui: oklch(1 0 0 / 0.14);
-  --gray-separator: oklch(0.348 0 0);
-  --gray-ring: oklch(1 0 0 / 0.231);
-  --gray-primary: oklch(0.949 0 0);
-  --gray-secondary: oklch(0.77 0 0);
-  --gray-muted: oklch(0.705 0 0);
-  --gray-disabled: oklch(0.586 0 0);
-  --gray-on-fill: oklch(0.178 0 0);
-
-  --accent-ui: oklch(0.597 0.221 258.03 / 0.227);
-  --accent-fill: oklch(0.649 0.193 251.78);
-  --accent-hover: oklch(0.587 0.227 258.962 / 0.341);
-  --accent-active: oklch(0.61 0.211 256.319 / 0.424);
-  --accent-focus: oklch(0.542 0.14 251.762);
-  --accent-focus-fill: oklch(0.636 0.2 253.539 / 0.941);
-  --accent-line-ui: oklch(0.674 0.191 252.9 / 0.572);
-  --accent-ring: oklch(0.662 0.184 252.588 / 0.588);
-  --accent-secondary: oklch(0.746 0.16 251.5);
-  --accent-primary: oklch(0.905 0.048 249.319);
-  --accent-solid-interactive: oklch(0.612 0.19 253.269); /* blue-800 */
-  --accent-border-2: oklch(0.664 0.181 252.459 / 0.725); /* blue-a600 */
-
-  --success-ui: oklch(0.894 0.202 145.082 / 0.106);
-  --success-fill: oklch(0.651 0.147 147.392);
-  --success-hover: oklch(0.888 0.22 146.073 / 0.173);
-  --success-active: oklch(0.894 0.207 145.856 / 0.231);
-  --success-focus: oklch(0.895 0.189 146.676 / 0.439);
-  --success-focus-fill: oklch(0.884 0.226 146.957 / 0.576);
-  --success-line-ui: oklch(0.894 0.191 146.754 / 0.365);
-  --success-ring: oklch(0.894 0.191 146.754 / 0.365);
-  --success-secondary: oklch(0.78 0.143 147.473);
-  --success-primary: oklch(0.91 0.077 147.124);
-  --success-on-fill: white;
-  --success-solid-interactive: oklch(0.61 0.146 147.408); /* green-800 */
-  --success-border-2: oklch(0.895 0.189 146.676 / 0.439); /* green-a600 */
-
-  --warning-ui: oklch(0.804 0.17 74.67 / 0.11);
-  --warning-fill: oklch(0.82 0.165 90.325);
-  --warning-hover: oklch(0.805 0.17 74.308 / 0.169);
-  --warning-active: oklch(0.818 0.171 77.948 / 0.224);
-  --warning-focus: oklch(0.536 0.089 90.735);
-  --warning-focus-fill: oklch(0.787 0.161 89.593);
-  --warning-line-ui: oklch(0.863 0.162 88.771 / 0.361);
-  --warning-ring: oklch(0.863 0.162 88.771 / 0.361);
-  --warning-secondary: oklch(0.871 0.162 90.498);
-  --warning-primary: oklch(0.936 0.067 91.506);
-  --warning-on-fill: black;
-  --warning-solid-interactive: oklch(0.787 0.161 89.593); /* yellow-800 */
-  --warning-border-2: oklch(0.877 0.16 90.2 / 0.471); /* yellow-a600 */
-
-  --destructive-ui: oklch(0.647 0.238 32.438 / 0.165);
-  --destructive-fill: oklch(0.664 0.179 34.086);
-  --destructive-hover: oklch(0.634 0.247 31.052 / 0.259);
-  --destructive-active: oklch(0.645 0.237 32.467 / 0.322);
-  --destructive-focus: oklch(0.538 0.13 33.898);
-  --destructive-focus-fill: oklch(0.625 0.179 34.149);
-  --destructive-line-ui: oklch(0.712 0.231 31.6 / 0.353);
-  --destructive-ring: oklch(0.698 0.19 34.508 / 0.49);
-  --destructive-secondary: oklch(0.77 0.138 35.323);
-  --destructive-primary: oklch(0.898 0.047 32.8);
-  --destructive-on-fill: white;
-  --destructive-solid-interactive: oklch(0.625 0.179 34.149); /* red-800 */
-  --destructive-border-2: oklch(0.708 0.184 33.964 / 0.655); /* red-a600 */
 }
 
-/* ------------------------------------------------
-   Theme scoping via data-theme attribute
-   Components set data-theme="accent" etc. and
-   semantic tokens get remapped automatically.
-   ------------------------------------------------ */
-
 [data-theme='accent'] {
-  --ui: var(--accent-ui);
-  --fill: var(--accent-fill);
-  --hover: var(--accent-hover);
-  --active: var(--accent-active);
-  --focus: var(--accent-focus);
-  --focus-fill: var(--accent-focus-fill);
-  /* line-ui @deprecated, use --ring instead */
-  --line-ui: var(--accent-line-ui);
-  --ring: var(--accent-ring);
-  --secondary: var(--accent-secondary);
-  --primary: var(--accent-primary);
-  --on-fill: var(--accent-on-fill);
-  --ui-label: var(--accent-secondary);
-
-  /* semantic layer (ADR-0008) */
-  --ui: var(--accent-ui);
-  --interactive-1: var(--accent-hover);
-  --interactive-2: var(--accent-active);
-  --interactive: var(--interactive-1);
-  --solid: var(--accent-fill);
-  --solid-interactive: var(--accent-solid-interactive);
-  --border-1: var(--accent-line-ui);
-  --border-2: var(--accent-border-2);
-  --border: var(--border-1);
-  --on-solid: var(--accent-on-fill);
+  --ui-subtle: var(--blue-a50);
+  --ui: var(--blue-a100);
+  --interactive-subtle: var(--blue-a100);
+  --interactive: var(--blue-a200);
+  --interactive-strong: var(--blue-a300);
+  --solid: var(--blue-700);
+  --solid-interactive: var(--blue-800);
+  --border-subtle: var(--blue-a400);
+  --border: var(--blue-a500);
+  --border-strong: var(--blue-a600);
+  --ring: var(--blue-600);
+  --primary: var(--blue-950);
+  --secondary: var(--blue-900);
+  --ui-label: var(--blue-900);
+  --on-solid: white;
 }
 
 [data-theme='destructive'] {
-  --ui: var(--destructive-ui);
-  --fill: var(--destructive-fill);
-  --hover: var(--destructive-hover);
-  --active: var(--destructive-active);
-  --focus: var(--destructive-focus);
-  --focus-fill: var(--destructive-focus-fill);
-  --line-ui: var(--destructive-line-ui);
-  --ring: var(--destructive-ring);
-  --secondary: var(--destructive-secondary);
-  --primary: var(--destructive-primary);
-  --on-fill: var(--destructive-on-fill);
-  --ui-label: var(--destructive-secondary);
-
-  /* semantic layer (ADR-0008) */
-  --ui: var(--destructive-ui);
-  --interactive-1: var(--destructive-hover);
-  --interactive-2: var(--destructive-active);
-  --interactive: var(--interactive-1);
-  --solid: var(--destructive-fill);
-  --solid-interactive: var(--destructive-solid-interactive);
-  --border-1: var(--destructive-line-ui);
-  --border-2: var(--destructive-border-2);
-  --border: var(--border-1);
-  --on-solid: var(--destructive-on-fill);
+  --ui-subtle: var(--red-a50);
+  --ui: var(--red-a100);
+  --interactive-subtle: var(--red-a100);
+  --interactive: var(--red-a200);
+  --interactive-strong: var(--red-a300);
+  --solid: var(--red-700);
+  --solid-interactive: var(--red-800);
+  --border-subtle: var(--red-a400);
+  --border: var(--red-a500);
+  --border-strong: var(--red-a600);
+  --ring: var(--red-600);
+  --primary: var(--red-950);
+  --secondary: var(--red-900);
+  --ui-label: var(--red-900);
+  --on-solid: white;
 }
 
 [data-theme='warning'] {
-  --ui: var(--warning-ui);
-  --fill: var(--warning-fill);
-  --hover: var(--warning-hover);
-  --active: var(--warning-active);
-  --focus: var(--warning-focus);
-  --focus-fill: var(--warning-focus-fill);
-  --line-ui: var(--warning-line-ui);
-  --ring: var(--warning-ring);
-  --secondary: var(--warning-secondary);
-  --primary: var(--warning-primary);
-  --on-fill: var(--warning-on-fill);
-  --ui-label: var(--warning-secondary);
-
-  /* semantic layer (ADR-0008) */
-  --ui: var(--warning-ui);
-  --interactive-1: var(--warning-hover);
-  --interactive-2: var(--warning-active);
-  --interactive: var(--interactive-1);
-  --solid: var(--warning-fill);
-  --solid-interactive: var(--warning-solid-interactive);
-  --border-1: var(--warning-line-ui);
-  --border-2: var(--warning-border-2);
-  --border: var(--border-1);
-  --on-solid: var(--warning-on-fill);
+  --ui-subtle: var(--yellow-a50);
+  --ui: var(--yellow-a100);
+  --interactive-subtle: var(--yellow-a100);
+  --interactive: var(--yellow-a200);
+  --interactive-strong: var(--yellow-a300);
+  --solid: var(--yellow-700);
+  --solid-interactive: var(--yellow-800);
+  --border-subtle: var(--yellow-a400);
+  --border: var(--yellow-a500);
+  --border-strong: var(--yellow-a600);
+  --ring: var(--yellow-600);
+  --primary: var(--yellow-950);
+  --secondary: var(--yellow-900);
+  --ui-label: var(--yellow-900);
+  --on-solid: black;
 }
 
 [data-theme='success'] {
-  --ui: var(--success-ui);
-  --fill: var(--success-fill);
-  --hover: var(--success-hover);
-  --active: var(--success-active);
-  --focus: var(--success-focus);
-  --focus-fill: var(--success-focus-fill);
-  --line-ui: var(--success-line-ui);
-  --ring: var(--success-ring);
-  --secondary: var(--success-secondary);
-  --primary: var(--success-primary);
-  --on-fill: var(--success-on-fill);
-  --ui-label: var(--success-secondary);
-
-  /* semantic layer (ADR-0008) */
-  --ui: var(--success-ui);
-  --interactive-1: var(--success-hover);
-  --interactive-2: var(--success-active);
-  --interactive: var(--interactive-1);
-  --solid: var(--success-fill);
-  --solid-interactive: var(--success-solid-interactive);
-  --border-1: var(--success-line-ui);
-  --border-2: var(--success-border-2);
-  --border: var(--border-1);
-  --on-solid: var(--success-on-fill);
+  --ui-subtle: var(--green-a50);
+  --ui: var(--green-a100);
+  --interactive-subtle: var(--green-a100);
+  --interactive: var(--green-a200);
+  --interactive-strong: var(--green-a300);
+  --solid: var(--green-700);
+  --solid-interactive: var(--green-800);
+  --border-subtle: var(--green-a400);
+  --border: var(--green-a500);
+  --border-strong: var(--green-a600);
+  --ring: var(--green-600);
+  --primary: var(--green-950);
+  --secondary: var(--green-900);
+  --ui-label: var(--green-900);
+  --on-solid: white;
 }
 
 @theme inline {
@@ -419,7 +133,7 @@
   --radius-full: 9999px;
 
   --color-background: var(--background);
-  --color-surface: var(--surface);
+  --color-subtle: var(--subtle);
   --color-overlay: var(--overlay);
   --color-ui: var(--ui);
   --color-fill: var(--fill);
@@ -440,44 +154,24 @@
   --color-ui-label: var(--ui-label);
 
   /* semantic layer (ADR-0008) */
-  --color-subtle: var(--subtle);
   --color-surface-1: var(--surface-1);
   --color-surface-2: var(--surface-2);
-  --color-interactive-1: var(--interactive-1);
-  --color-interactive-2: var(--interactive-2);
+  --color-ui-subtle: var(--ui-subtle);
+  --color-interactive-subtle: var(--interactive-subtle);
   --color-interactive: var(--interactive);
+  --color-interactive-strong: var(--interactive-strong);
   --color-solid: var(--solid);
   --color-solid-interactive: var(--solid-interactive);
-  --color-border-1: var(--border-1);
-  --color-border-2: var(--border-2);
+  --color-border-subtle: var(--border-subtle);
   --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
   --color-on-solid: var(--on-solid);
-
-  --color-gray-background: var(--gray-background);
-  --color-gray-surface: var(--gray-surface);
-  --color-gray-overlay: var(--gray-overlay);
-  --color-gray-ui: var(--gray-ui);
-  --color-gray-fill: var(--gray-fill);
-  --color-gray-hover: var(--gray-hover);
-  --color-gray-active: var(--gray-active);
-  --color-gray-focus: var(--gray-focus);
-  --color-gray-focus-fill: var(--gray-focus-fill);
-  --color-gray-line: var(--gray-line);
-  --color-gray-line-subtle: var(--gray-line-subtle);
-  --color-gray-line-ui: var(--gray-line-ui);
-  --color-gray-separator: var(--gray-separator);
-  --color-gray-ring: var(--gray-ring);
-  --color-gray-primary: var(--gray-primary);
-  --color-gray-secondary: var(--gray-secondary);
-  --color-gray-muted: var(--gray-muted);
-  --color-gray-disabled: var(--gray-disabled);
-  --color-gray-on-fill: var(--gray-on-fill);
 }
 
 /* Shiki dual-theme: map code block backgrounds to Ora surface token */
 :root {
-  --shiki-light-bg: var(--surface);
-  --shiki-dark-bg: var(--surface);
+  --shiki-light-bg: var(--subtle);
+  --shiki-dark-bg: var(--subtle);
 }
 
 /* Syntax token colors: light mode uses --shiki-light, dark uses --shiki-dark */

--- a/docs/COMPONENT-GUIDE.md
+++ b/docs/COMPONENT-GUIDE.md
@@ -77,7 +77,7 @@ Build in this order:
 1. **Types** — define the variant, theme, and prop types
 2. **CVA definition** — structural styles using semantic tokens
    (see [Conventions — CVA variant definition](conventions/INDEX.md#cva-variant-definition))
-   - Use semantic token classes: `bg-ui-1`, `text-primary`, `border-border-1`
+   - Use semantic token classes: `bg-ui`, `text-primary`, `border-border-1`
    - Variants define visual hierarchy: solid, outline, surface, soft, ghost
    - Each variant uses appropriate semantic tokens for its background/text/border
 3. **CSS custom properties** — define component-scoped custom properties

--- a/docs/adr/0008-interim-role-layer-for-tokens.md
+++ b/docs/adr/0008-interim-role-layer-for-tokens.md
@@ -71,33 +71,46 @@ semantic layer in the middle:
    isolation. Out of scope for this ADR; covered case-by-case as
    components grow.
 
-### The semantic layer — 17 tokens
+### The semantic layer — 18 tokens
 
-| Domain                | Tokens                                                                   | Notes                                                                                                                                                                                                            |
-| --------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Background & Surfaces | `--background`, `--surface-1`, `--surface-2`, `--surface-3`, `--overlay` | Ordinal ladder (1 = subtle raised → 3 = most raised). `--overlay` is distinct: matches `--background` in light mode, steps up to the first solid surface in dark.                                                |
-| UI                    | `--ui-1`, `--ui-2`, `--ui-3`                                             | Soft interactive container, alpha-based, three strength levels.                                                                                                                                                  |
-| Solid                 | `--solid-1`, `--solid-2`                                                 | Emphatic fill, two strength levels. Hover/active modulation via alpha against `--solid-2`.                                                                                                                       |
-| Borders               | `--separator`, `--border-1`, `--border-2`                                | `--separator` is solid (layout/structural). `--border-N` are alpha (ui-element borders that tint with theme).                                                                                                    |
-| Outline               | `--ring`                                                                 | Focus ring and decorative outlines. One value works for solid backgrounds via outline-offset.                                                                                                                    |
-| Foreground            | `--primary`, `--secondary`, `--ui-label`, `--on-solid`                   | Covers text and icon fills. `--primary`/`--secondary` are the two-tier hierarchy. `--ui-label` and `--on-solid` are contextual companions, used when painting on `--ui-N` and `--solid-N` surfaces respectively. |
+| Domain                | Tokens                                                                | Notes                                                                                                                                                                                                                        |
+| --------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Background & Surfaces | `--background`, `--subtle`, `--surface-1`, `--surface-2`, `--overlay` | `--subtle` is a solid surface one notch above the floor. `--surface-N` is an ordinal ladder (1 = subtle raised → 2 = most raised). `--overlay` matches `--background` in light, steps up to the first solid surface in dark. |
+| UI                    | `--ui`, `--interactive-1`, `--interactive-2`                          | Soft interactive container, alpha-based. `--ui` rests; `--interactive-N` are its interaction weights. Bare `--interactive` aliases step 1.                                                                                   |
+| Solid                 | `--solid`, `--solid-interactive`                                      | Emphatic fill: a resting fill plus its interaction weight. Replaces the `bg-fill/90` hover hack. Deeper states handled per-component.                                                                                        |
+| Borders               | `--separator`, `--border-1`, `--border-2`                             | `--separator` is solid (layout/structural). `--border-N` are alpha (ui-element borders that tint with theme). Bare `--border` aliases step 1.                                                                                |
+| Outline               | `--ring`                                                              | Focus ring and decorative outlines. One value works for solid backgrounds via outline-offset.                                                                                                                                |
+| Foreground            | `--primary`, `--secondary`, `--ui-label`, `--on-solid`                | Covers text and icon fills. `--primary`/`--secondary` are the two-tier hierarchy. `--ui-label` and `--on-solid` are contextual companions, used when painting on `--ui` and `--solid` surfaces respectively.                 |
 
-### Naming convention: ordinal strength, not interaction state
+(Bare aliases `--interactive`, `--border` are ergonomic duplicates of step 1, not counted in the 18.)
 
-Tokens in a strength ladder (`--ui-N`, `--solid-N`, `--surface-N`,
-`--border-N`) are named by intensity, not by which interaction
-state they "belong to". A component is free to map any interaction
-state to any strength level based on visual intent:
+### Naming convention: ordinal ladders + a rest/interactive split
 
-- Button `:hover` reads `--ui-2`; `:active` reads `--ui-3`. Default
-  mapping.
-- Toggle `[data-pressed]` reads `--ui-2` because pressed wants that
-  weight, not deeper. Correct usage, not a workaround.
-- Tabs `[data-selected]` reads `--ui-3`. Selected wants the strongest
-  weight in this component.
+Two shapes, each applied where it is honest:
 
-The strength ladder is the contract; the state→strength mapping is a
-component decision. This is the explicit fix for the `active/75`
+- **Ordinal strength** where a true intensity ladder exists
+  (`--surface-N`, `--border-N`): named by intensity, not by which
+  state they "belong to". A component maps any state to any level by
+  visual intent.
+- **Rest / interactive split** where the meaningful distinction is
+  interaction rather than raw intensity (`--ui` vs `--interactive-N`,
+  `--solid` vs `--solid-interactive`): the resting token is where a
+  control sits, the interactive token(s) where it goes when touched.
+
+The original draft made everything a pure ordinal ladder (`--ui-N`,
+`--solid-N`). In practice the soft-container and solid families have a
+clear rest state plus one or two interaction weights, and naming them
+`--ui` / `--interactive-N`, `--solid` / `--solid-interactive` reads
+truer than `--ui-1/2/3`. The interaction problem the ordinal scheme
+was solving lived in the old `--hover` / `--active` _state_ tokens, not
+in `--ui` itself — so `--ui` returns as the single resting container,
+and the interaction weights become an ordinal `--interactive-N`
+sub-ladder.
+
+Which state reads which token stays a component decision (e.g. a
+Toggle's pressed state may read `--interactive-1` rather than the
+deeper weight). States past what the tokens name are handled via alpha
+or component vars. This is the fix for the `active/75`, `bg-fill/90`
 escape-hatch family.
 
 ### Layout vs ui borders: solid vs alpha
@@ -117,7 +130,7 @@ not new tokens.
 
 ### Alpha modifiers as a sanctioned escape hatch
 
-Components are free to use `bg-ui-1/50`, `bg-ui-2/50`, `border-border-1/80`
+Components are free to use `bg-ui/50`, `bg-interactive-1/50`, `border-border-1/80`
 etc. for **subtle contextual modulation of the same role**. The
 canonical case: a surface button variant has a border, so its
 container fill wants less weight than a soft button's container fill
@@ -131,15 +144,15 @@ The line between sanctioned modulation and "missing token" is intent:
   adjacent affordance.
 - Missing token: reaching for a value that conceptually wants its own
   name (e.g. `bg-fill/90` for solid button hover — the fix was to add
-  `--solid-2`, not normalise the hack).
+  `--solid-interactive`, not normalise the hack).
 
 ### Theme remapping
 
 `[data-theme="X"]` continues to remap the semantic layer onto themed
-scales. The 17-token contract means each themed palette must
+scales. The 18-token contract means each themed palette must
 implement the same set of slots — no more asymmetric coverage. New
 themes (success, warning, a brand palette, an entire alternative
-aesthetic) implement the same 17 slots.
+aesthetic) implement the same 18 slots.
 
 ## Alternatives considered
 
@@ -158,7 +171,7 @@ Rejected. Three problems:
    to override `--button-*`, `--input-*`, `--card-*`, … even when the
    intent is "same change everywhere". The semantic layer collapses
    that into one or two lines.
-3. Tailwind ergonomics suffer. `bg-ui-2 hover:bg-ui-3` reads
+3. Tailwind ergonomics suffer. `bg-ui hover:bg-interactive-1` reads
    beautifully; `bg-[--button-bg] hover:bg-[--button-bg-hover]`
    doesn't. The semantic layer lets utility classes stay terse.
 4. The "shared interfaces" rescue recreates the role layer at a less
@@ -170,11 +183,18 @@ Rejected. Three problems:
 Keep `--ui-hover`/`--ui-active`, document that components may map any
 interaction state to any level by intent.
 
-Rejected. Too clever for a contract layer 30+ contributors will
-touch. The token name encodes a contract, and "name says hover but
-component uses it for pressed" requires reading docs to use
-correctly. Ordinal naming is honest: the contract is intensity, and
-the name describes intensity.
+Rejected as the _wholesale_ scheme. Naming every level after a
+specific interaction state (`--ui-hover` used for a pressed state) is
+too clever for a contract layer 30+ contributors touch. But the final
+design is not pure-ordinal either: it keeps ordinal where a real
+intensity ladder exists (`--surface-N`, `--border-N`) and uses a
+rest/interactive split where interaction is the actual distinction
+(`--ui`/`--interactive-N`, `--solid`/`--solid-interactive`).
+`--interactive` is not a specific-state name — it's "the interacted
+weight", with the exact state→token mapping left to the component.
+That keeps the honesty (the name describes what the value is) without
+forcing soft-container and solid fills through an awkward `-1/2/3`
+ladder.
 
 ### Radix-12 ramp as the contract
 
@@ -231,16 +251,17 @@ mental model.
 
 **Positive:**
 
-- 17 semantic tokens, down from ~25. Less to remember, fewer
+- 18 semantic tokens, down from ~25. Less to remember, fewer
   ambiguous reaches.
-- Symmetric strength ladders for `--ui-N` and `--solid-N` kill the
-  `bg-fill/90` / `bg-ui/25` opacity-hatch family.
-- Components are free to map any interaction state to any strength
-  level by visual intent. No more state-name mismatch hacks.
+- A rest/interactive split (`--ui`/`--interactive-N`,
+  `--solid`/`--solid-interactive`) plus ordinal border/surface ladders
+  kill the `bg-fill/90` / `bg-ui/25` opacity-hatch family.
+- Components are free to map any interaction state to any interactive
+  weight by visual intent. No more state-name mismatch hacks.
 - Layout vs ui distinction encoded in `--separator` (solid) vs
   `--border-N` (alpha). The value type _is_ the role.
 - Theme remapping contract is uniform — every themed palette
-  implements the same 17 slots. New themes (game, expressive,
+  implements the same 18 slots. New themes (game, expressive,
   RYBitten-style) drop into the same shape.
 - Alpha modulation becomes a sanctioned, documented escape hatch for
   same-role contextual softening, rather than a smell.
@@ -262,7 +283,7 @@ mental model.
 ## Followups
 
 - Full rewrite of `docs/conventions/TOKEN-SYSTEM.md` against the
-  three-tier model, the 17-token contract, the naming convention,
+  three-tier model, the 18-token contract, the naming convention,
   and the alpha-modifier policy. Absorbs the existing
   `Performance Contract` section's radius warning as a one-liner
   inside the Radius section; drops the rest.

--- a/docs/adr/0008-token-architecture.md
+++ b/docs/adr/0008-token-architecture.md
@@ -83,11 +83,15 @@ as components grow.
 
 Concrete color scales. For Ora's base theme:
 
-- **Gray**: track Radix's step semantics. Eleven steps,
-  `--gray-1`..`--gray-11`, plus alpha variants `--gray-a1`..`--gray-a11`.
+- **Gray**: track Radix's step _semantics_ (which step plays which
+  role) while keeping Ora's existing Tailwind-style scale names —
+  `--gray-50`..`--gray-950`, plus alpha variants
+  `--gray-a50`..`--gray-a950`. The `colors.css` comments
+  (`/* radix-step-2 */` etc.) record the Radix step each value maps to.
   Radix's step 1 (the app-background floor) is omitted at the scale
-  layer — that role is held by the semantic `--background` token, not
-  re-exposed as a scale step. The old `--gray-base` retires.
+  layer — that role is held by the
+  semantic `--background` token, not re-exposed as a scale step. The
+  old `--gray-base` retires.
 - **Accent palettes** (blue, indigo, etc.): custom values authored
   in Ora's codebase via Radix's color generator as a sketching tool,
   then vendored as Ora's values. No runtime dependency on
@@ -128,17 +132,17 @@ These read from the gray scale by default:
 
 ```css
 :root {
-  --ui-subtle: var(--gray-a2);
-  --ui: var(--gray-a3);
-  --interactive-subtle: var(--gray-a3);
-  --interactive: var(--gray-a4);
-  --interactive-strong: var(--gray-a5);
-  --solid: var(--gray-11);
-  --solid-interactive: var(--gray-10);
-  --border-subtle: var(--gray-a6);
-  --border: var(--gray-a7);
-  --border-strong: var(--gray-a8);
-  --ui-label: var(--gray-11);
+  --ui-subtle: var(--gray-a50);
+  --ui: var(--gray-a100);
+  --interactive-subtle: var(--gray-a100);
+  --interactive: var(--gray-a200);
+  --interactive-strong: var(--gray-a300);
+  --solid: var(--gray-900);
+  --solid-interactive: var(--gray-800);
+  --border-subtle: var(--gray-a400);
+  --border: var(--gray-a500);
+  --border-strong: var(--gray-a600);
+  --ui-label: var(--gray-900);
   /* …etc */
 }
 ```
@@ -184,17 +188,17 @@ accent's scale, without an intermediate role-binding token like
 
 ```css
 [data-theme='accent'] {
-  --ui-subtle: var(--blue-a2);
-  --ui: var(--blue-a3);
-  --interactive-subtle: var(--blue-a3);
-  --interactive: var(--blue-a4);
-  --interactive-strong: var(--blue-a5);
-  --solid: var(--blue-9);
-  --solid-interactive: var(--blue-10);
-  --border-subtle: var(--blue-a6);
-  --border: var(--blue-a7);
-  --border-strong: var(--blue-a8);
-  --ui-label: var(--blue-a11);
+  --ui-subtle: var(--blue-a50);
+  --ui: var(--blue-a100);
+  --interactive-subtle: var(--blue-a100);
+  --interactive: var(--blue-a200);
+  --interactive-strong: var(--blue-a300);
+  --solid: var(--blue-700);
+  --solid-interactive: var(--blue-800);
+  --border-subtle: var(--blue-a400);
+  --border: var(--blue-a500);
+  --border-strong: var(--blue-a600);
+  --ui-label: var(--blue-a900);
   /* …etc */
 }
 ```
@@ -211,7 +215,7 @@ surface tokens (`--background`, `--subtle`, `--surface-1`,
 appear under `:root` only and are absent from theme blocks
 intentionally.
 
-Dark mode is handled at the scale layer (`.dark { --gray-3: ...; }`)
+Dark mode is handled at the scale layer (`.dark { --gray-100: ...; }`)
 per Radix's standard. Semantic tokens and `[data-theme]` blocks are
 mode-agnostic — they read scale token names that self-swap.
 
@@ -289,12 +293,13 @@ directly.
 
 ### Pure scale exposure (no semantic layer)
 
-Rejected. Components reading `bg-gray-a3` / `bg-blue-a3` directly
+Rejected. Components reading `bg-gray-a100` / `bg-blue-a100` directly
 loses the semantic naming layer that makes intent legible at the read
-site. `bg-ui` says "this is a ui surface"; `bg-gray-a3` says "this is
-gray-3" and requires the reader to know that gray-3 is the ui-surface
-step. Worse, it forces theme-awareness into every component (each one
-would need to know which scale to read from per theme).
+site. `bg-ui` says "this is a ui surface"; `bg-gray-a100` says "this is
+gray-a100" and requires the reader to know that it maps to the
+ui-surface step (Radix step 3). Worse, it forces theme-awareness into
+every component (each one would need to know which scale to read from
+per theme).
 
 ### Drift detection script with CSS-inline waivers
 
@@ -344,18 +349,20 @@ intentional exceptions without polluting consumer-owned CSS.
 
 ## Followups
 
-- **Phase 1 (additive prep, can ship anytime):** rename scale tokens
-  in `colors.css` from Tailwind-style (`--gray-50`/`--gray-100`/...) to
-  Radix step style (`--gray-1`..`--gray-11`, `--gray-a1`..`--gray-a11`).
-  Drop `--gray-base` and the Radix step-1 floor; the `--background`
-  semantic token holds that role instead. Verify Tailwind `@theme
-inline` block + colors.css consumers are updated in lockstep so no
-  utility class breaks.
+- **Phase 1 (additive prep, done):** drop `--gray-base` (the Radix
+  step-1 / app-background floor) from `colors.css`; the `--background`
+  semantic token holds that role instead. Scale tokens keep their
+  existing Tailwind-style names (`--gray-50`..`--gray-950`,
+  `--gray-a50`..`--gray-a950`); the Radix-step _rename_ originally
+  scoped here was dropped — the cost of a breaking rename across
+  utilities (`bg-gray-50`) and `var()` consumers wasn't worth it, and
+  Radix-step semantics are already captured by the
+  `/* radix-step-N */` comments in `colors.css`.
 - **Phase 2 (cut-over, one focused diff):** rewrite semantic tokens to
   read from scale directly, retire `--gray-ui` / `--accent-ui` / etc.
   role-binding variables, rewrite `[data-theme]` blocks to retarget
-  inline against scale. Promote `--ui-subtle` (reads `--gray-a2` in
-  base, `--blue-a2` under `[data-theme=accent]`) — the canonical
+  inline against scale. Promote `--ui-subtle` (reads `--gray-a50` in
+  base, `--blue-a50` under `[data-theme=accent]`) — the canonical
   example of an alpha-modifier escape hatch becoming a real semantic
   token. Apply the naming refinement: replace any
   `--interactive-1/--interactive-2` (interim ADR shape) with

--- a/docs/adr/0008-token-architecture.md
+++ b/docs/adr/0008-token-architecture.md
@@ -2,7 +2,29 @@
 
 ## Status
 
-Proposed — 2026-06-08
+Proposed — 2026-06-09
+
+## Relationship to ADR-0008 (interim role layer)
+
+This ADR sits alongside `0008-interim-role-layer-for-tokens.md`. The
+two share a number; they cover different cuts of the same decision:
+
+- **The interim ADR is the contract**: the 18-token semantic layer
+  shape, naming convention (rest/interactive split + ordinal ladders
+  - adjective triads, refined below), the layout-vs-ui borders
+    distinction, the alpha-modifier escape-hatch policy, and the
+    rejection of Radix-12 as a _cross-theme_ contract.
+- **This ADR is the implementation strategy** for Ora's base theme:
+  how the scale layer is sourced (Radix step semantics for gray and
+  custom accents), how `[data-theme]` retargeting works without an
+  intermediate role-binding layer, how docs serve as the spec, how
+  promotion of new semantic tokens is governed, and how migration
+  sequences.
+
+Read both. Where they appear to disagree, the interim ADR wins on
+contract questions (token names, naming convention, theming model);
+this ADR wins on implementation questions (how the scale layer is
+authored, how `[data-theme]` blocks resolve, migration sequencing).
 
 ## Context
 
@@ -51,74 +73,155 @@ _from_.
 
 ## Decision
 
-Restructure tokens into two layers, with theme switching happening at
-the semantic-token site via inline retargeting under `[data-theme]`.
+Adopt the three-tier architecture established in the interim ADR
+(Scale → Semantic → Component vars), with theme switching happening
+at the semantic-token site via inline retargeting under `[data-theme]`.
+Component vars are out of scope for this ADR and covered case-by-case
+as components grow.
 
 ### Layer 1 — Scale (foundation)
 
-Concrete color scales using Radix's step semantics:
+Concrete color scales. For Ora's base theme:
 
-- **Gray**: track Radix's gray scales directly (`--gray-1` through
-  `--gray-12`, plus alpha variants `--gray-a1`..`--gray-a12`).
+- **Gray**: track Radix's step semantics. Eleven steps,
+  `--gray-1`..`--gray-11`, plus alpha variants `--gray-a1`..`--gray-a11`.
+  Radix's step 1 (the app-background floor) is omitted at the scale
+  layer — that role is held by the semantic `--background` token, not
+  re-exposed as a scale step. The old `--gray-base` retires.
 - **Accent palettes** (blue, indigo, etc.): custom values authored
-  via Radix's color generator, holding the same step semantics as
-  the Radix scales. This preserves brand identity while keeping the
-  step contract.
+  in Ora's codebase via Radix's color generator as a sketching tool,
+  then vendored as Ora's values. No runtime dependency on
+  `@radix-ui/colors`.
 
-Scale tokens are intentionally exposed — components and consumers can
-reach for them when no semantic token fits, as a documented escape
-hatch (see "Semantic-first rule" below).
+Scale tokens are intentionally exposed. Components and consumers can
+reach for them as a documented escape hatch when no semantic token
+fits (see "Semantic-first rule" below). The previous concern about
+scale-token bloat in the consumer interface is treated as something
+that earns its keep through real complaints, not something hidden
+preemptively.
+
+**Cross-theme note:** Radix step semantics are _Ora's base-theme
+implementation_, not the contract. Per the interim ADR, the 18 token
+roles are the cross-theme contract; other themes (game UI, brutalist,
+RYBitten-style) may map those roles to their own scale shapes that
+don't follow a lightness ramp at all.
 
 ### Layer 2 — Semantic (API)
 
-Semantic tokens (`--ui`, `--hover`, `--fill`, `--line-ui`, etc.)
-defined once under `:root`, reading from the gray scale by default:
+The 18-token semantic layer defined in the interim ADR. This is the
+consumer-facing API; components reach for these first when authoring
+styles.
+
+The current set, with naming refinements landed alongside this ADR:
+
+```
+Backgrounds & Surfaces:  --background, --subtle, --surface-1, --surface-2, --overlay
+UI:                      --ui-subtle, --ui
+Interactive:             --interactive-subtle, --interactive, --interactive-strong
+Solid:                   --solid, --solid-interactive
+Borders:                 --separator, --border-subtle, --border, --border-strong
+Focus:                   --ring
+Foreground:              --primary, --secondary, --ui-label, --on-solid
+```
+
+These read from the gray scale by default:
 
 ```css
 :root {
+  --ui-subtle: var(--gray-a2);
   --ui: var(--gray-a3);
-  --hover: var(--gray-a4);
-  --active: var(--gray-a5);
-  --fill: var(--gray-12);
-  --ui-label: var(--gray-12);
+  --interactive-subtle: var(--gray-a3);
+  --interactive: var(--gray-a4);
+  --interactive-strong: var(--gray-a5);
+  --solid: var(--gray-11);
+  --solid-interactive: var(--gray-10);
+  --border-subtle: var(--gray-a6);
+  --border: var(--gray-a7);
+  --border-strong: var(--gray-a8);
+  --ui-label: var(--gray-11);
+  /* …etc */
 }
 ```
 
-These are the consumer-facing API. Components should reach for these
-first when authoring styles.
+### Naming convention (refinement on the interim ADR)
 
-### Theme switching — inline retargeting, no alias layer
+The interim ADR established "ordinal ladders + rest/interactive split."
+Continued work surfaced a sharper underlying rule that absorbs both
+patterns and resolves what to do when a family has more than two steps:
+
+- **Bare name = the token to reach for by default.** Most call sites
+  get the short name; specialised cases pay the suffix cost.
+- **Capped family with a default** → adjective triad
+  (`-subtle`, bare, `-strong`). Suffixes mark deviations from the
+  default. Used where steps represent qualitatively different intents
+  at the same role: `--ui-subtle/--ui`, `--interactive-subtle
+/--interactive/--interactive-strong`, `--border-subtle/--border
+/--border-strong`.
+- **Elastic family** → ordinal. Used where elevation, weight, or
+  other axes are intrinsically extensible:
+  `--surface-1/--surface-2/--surface-N`. (No member of the elastic
+  family currently exceeds 2; the ordinal pattern leaves room.)
+- **Rest + single interaction weight pair** → bare + `-interactive`
+  suffix: `--solid/--solid-interactive`.
+
+The honest test for adjective vs ordinal: do the steps represent
+_different intents_ or _different intensities of the same intent_?
+Different intents → adjective triad. Different intensities → ordinal.
+
+Borders use adjective because Radix's documented step roles (6 =
+decorative line, 7 = ui element border, 8 = hovered/emphasised
+border) are qualitatively distinct. Interactive uses adjective
+because the bare-name-as-default property genuinely matters here —
+step 4 is the typical hover weight; ordinal naming (`--interactive-1`
+at step 3) would mislead users into treating the edge-case weight as
+the default.
+
+### Theme switching — inline retargeting, no role-binding layer
 
 `[data-theme]` blocks retarget semantic tokens directly to the chosen
-accent's scale, without an intermediate alias:
+accent's scale, without an intermediate role-binding token like
+`--gray-ui` or `--accent-ui`:
 
 ```css
 [data-theme='accent'] {
+  --ui-subtle: var(--blue-a2);
   --ui: var(--blue-a3);
-  --hover: var(--blue-a4);
-  --active: var(--blue-a5);
-  --fill: var(--blue-9);
+  --interactive-subtle: var(--blue-a3);
+  --interactive: var(--blue-a4);
+  --interactive-strong: var(--blue-a5);
+  --solid: var(--blue-9);
+  --solid-interactive: var(--blue-10);
+  --border-subtle: var(--blue-a6);
+  --border: var(--blue-a7);
+  --border-strong: var(--blue-a8);
   --ui-label: var(--blue-a11);
+  /* …etc */
 }
 ```
 
-The `--accent-ui` / `--accent-hover` / `--accent-fill` alias-layer
-tokens are retired. Adding a new themed semantic token means: define
-it under `:root` reading from the gray scale, add a line per
-`[data-theme]` block reading from that theme's scale. No third
-definition step.
+The `--gray-ui` / `--accent-ui` / etc. role-binding tokens currently
+in `globals.css` retire as part of the migration. Adding a new themed
+semantic token means: define it under `:root` reading from the gray
+scale, add a line per `[data-theme]` block reading from that theme's
+scale. No third definition step.
 
 Not every semantic token belongs in `[data-theme]`. Chrome-level
-surface tokens (`--background`, `--surface`, `--overlay`) stay neutral
-regardless of accent — they appear under `:root` only and are absent
-from theme blocks intentionally.
+surface tokens (`--background`, `--subtle`, `--surface-1`,
+`--surface-2`, `--overlay`) stay neutral regardless of accent — they
+appear under `:root` only and are absent from theme blocks
+intentionally.
+
+Dark mode is handled at the scale layer (`.dark { --gray-3: ...; }`)
+per Radix's standard. Semantic tokens and `[data-theme]` blocks are
+mode-agnostic — they read scale token names that self-swap.
 
 ### Step-parity is the default, not a rule
 
 Most semantic tokens read the same step number across base and theme
 blocks (`--ui` reads step 3 everywhere). Some do not, by design:
-`--ui-label` reads step 12 in base but step 11 in accent themes,
-because colored accents at step 12 oversaturate as label text.
+`--ui-label` reads step 11 in base but reads a different step (often
+the alpha variant of step 11) in accent themes, because colored
+accents at the deepest step oversaturate as label text.
 
 These intentional step shifts are documented in TOKEN-SYSTEM.md, not
 encoded in CSS. The CSS expresses what each token _is_; the docs
@@ -241,16 +344,26 @@ intentional exceptions without polluting consumer-owned CSS.
 
 ## Followups
 
-- **Phase 1 (additive prep, can ship anytime):** introduce scale tokens
-  in `globals.css` alongside the existing semantic + role-binding
-  setup. No behavior change; lets value choices be spot-checked in
-  isolation.
+- **Phase 1 (additive prep, can ship anytime):** rename scale tokens
+  in `colors.css` from Tailwind-style (`--gray-50`/`--gray-100`/...) to
+  Radix step style (`--gray-1`..`--gray-11`, `--gray-a1`..`--gray-a11`).
+  Drop `--gray-base` and the Radix step-1 floor; the `--background`
+  semantic token holds that role instead. Verify Tailwind `@theme
+inline` block + colors.css consumers are updated in lockstep so no
+  utility class breaks.
 - **Phase 2 (cut-over, one focused diff):** rewrite semantic tokens to
-  read from scale, retire the `--gray-ui` / `--accent-ui` / etc.
+  read from scale directly, retire `--gray-ui` / `--accent-ui` / etc.
   role-binding variables, rewrite `[data-theme]` blocks to retarget
-  inline. Phase 2 also promotes `--ui-subtle` (reads `--gray-a2` in
-  base, accent-2 under `[data-theme=accent]`) — the canonical example
-  of an alpha-modifier escape hatch becoming a real semantic token.
+  inline against scale. Promote `--ui-subtle` (reads `--gray-a2` in
+  base, `--blue-a2` under `[data-theme=accent]`) — the canonical
+  example of an alpha-modifier escape hatch becoming a real semantic
+  token. Apply the naming refinement: replace any
+  `--interactive-1/--interactive-2` (interim ADR shape) with
+  `--interactive-subtle/--interactive/--interactive-strong`; replace
+  `--border-1/--border-2` with `--border-subtle/--border/--border-strong`.
+- **Button as canary:** before sweeping other components, port Button
+  to the new system and validate behaviour in light/dark, gray/accent
+  contexts. Other components follow once Button confirms the system.
 - **Migration is independent of the eager Entry-schema migration
   (ADR-0007).** They share no risk surface and should not be batched —
   coupling them lets either's iteration block the other.
@@ -267,8 +380,3 @@ intentional exceptions without polluting consumer-owned CSS.
 - Build a drift detection script if drift between docs and CSS
   becomes felt pain. The table format is designed to support this
   without restructuring.
-- **Scale source:** all scale values are custom-authored in Ora's
-  codebase. The Radix color generator is used as a sketching tool;
-  its output is vendored into Ora's `colors.css` as Ora's values, not
-  imported from `@radix-ui/colors`. Keeps full control over the
-  scale and avoids a runtime dependency.

--- a/docs/adr/0008-token-architecture.md
+++ b/docs/adr/0008-token-architecture.md
@@ -1,0 +1,274 @@
+# ADR-0008: Token architecture (scale foundation, semantic API, inline theme retargeting)
+
+## Status
+
+Proposed — 2026-06-08
+
+## Context
+
+Ora's current token system (documented in `docs/conventions/TOKEN-SYSTEM.md`)
+defines semantic tokens directly with hex values and uses a per-theme
+alias layer to support themed components:
+
+```css
+:root {
+  --ui: oklch(0 0 0 / 0.059);
+  --accent-ui: var(--accent-3);
+  /* ...one --accent-* alias per semantic token... */
+}
+
+[data-theme='accent'] {
+  --ui: var(--accent-ui);
+  --hover: var(--accent-hover);
+  /* ...one remap per token... */
+}
+```
+
+This shipped, works, and has carried Ora through pre-alpha. Three
+observations from continued use forced a rethink:
+
+- **Alpha-modifier escape hatches accumulate.** Components reach for
+  `bg-ui/50` or `text-foreground/50` whenever a token doesn't quite
+  fit. The opacity modifier is doing the work a real semantic token
+  should do — and it doesn't survive theme swaps cleanly (alpha on a
+  light surface ≠ alpha on a dark surface).
+- **The alias layer (`--accent-ui`, `--accent-hover`, `--accent-fill`,
+  `--accent-line-ui`, `--accent-ui-label`, etc.) doubles the surface
+  area** of the token system without adding a layer of meaning.
+  Adding a new semantic token requires defining it twice (base +
+  accent) plus a third line in every `[data-theme]` block.
+- **No principled foundation for the semantic tokens to _derive_
+  from.** Values are hand-picked per token. Step relationships
+  between tokens (`--hover` slightly darker than `--ui`, `--active`
+  slightly darker again) are implicit, not enforced by structure.
+
+Radix Colors solves the foundational layer well: a 12-step scale per
+palette, each step assigned a designated use case (3 = ui element
+background, 4 = hovered ui, 5 = active ui, 6 = subtle border,
+7 = ui border, 9 = solid fill, 11 = low-contrast text, 12 = high-
+contrast text). Adopting it gives the semantic tokens a place to read
+_from_.
+
+## Decision
+
+Restructure tokens into two layers, with theme switching happening at
+the semantic-token site via inline retargeting under `[data-theme]`.
+
+### Layer 1 — Scale (foundation)
+
+Concrete color scales using Radix's step semantics:
+
+- **Gray**: track Radix's gray scales directly (`--gray-1` through
+  `--gray-12`, plus alpha variants `--gray-a1`..`--gray-a12`).
+- **Accent palettes** (blue, indigo, etc.): custom values authored
+  via Radix's color generator, holding the same step semantics as
+  the Radix scales. This preserves brand identity while keeping the
+  step contract.
+
+Scale tokens are intentionally exposed — components and consumers can
+reach for them when no semantic token fits, as a documented escape
+hatch (see "Semantic-first rule" below).
+
+### Layer 2 — Semantic (API)
+
+Semantic tokens (`--ui`, `--hover`, `--fill`, `--line-ui`, etc.)
+defined once under `:root`, reading from the gray scale by default:
+
+```css
+:root {
+  --ui: var(--gray-a3);
+  --hover: var(--gray-a4);
+  --active: var(--gray-a5);
+  --fill: var(--gray-12);
+  --ui-label: var(--gray-12);
+}
+```
+
+These are the consumer-facing API. Components should reach for these
+first when authoring styles.
+
+### Theme switching — inline retargeting, no alias layer
+
+`[data-theme]` blocks retarget semantic tokens directly to the chosen
+accent's scale, without an intermediate alias:
+
+```css
+[data-theme='accent'] {
+  --ui: var(--blue-a3);
+  --hover: var(--blue-a4);
+  --active: var(--blue-a5);
+  --fill: var(--blue-9);
+  --ui-label: var(--blue-a11);
+}
+```
+
+The `--accent-ui` / `--accent-hover` / `--accent-fill` alias-layer
+tokens are retired. Adding a new themed semantic token means: define
+it under `:root` reading from the gray scale, add a line per
+`[data-theme]` block reading from that theme's scale. No third
+definition step.
+
+Not every semantic token belongs in `[data-theme]`. Chrome-level
+surface tokens (`--background`, `--surface`, `--overlay`) stay neutral
+regardless of accent — they appear under `:root` only and are absent
+from theme blocks intentionally.
+
+### Step-parity is the default, not a rule
+
+Most semantic tokens read the same step number across base and theme
+blocks (`--ui` reads step 3 everywhere). Some do not, by design:
+`--ui-label` reads step 12 in base but step 11 in accent themes,
+because colored accents at step 12 oversaturate as label text.
+
+These intentional step shifts are documented in TOKEN-SYSTEM.md, not
+encoded in CSS. The CSS expresses what each token _is_; the docs
+explain _why_.
+
+### Semantic-first rule
+
+Authors reach for semantic tokens first. When no semantic token fits,
+they reach for the scale token directly _with intent_. Repeated
+scale-direct reaches are the signal that a new semantic token should
+be promoted.
+
+The promotion decision is curator-held (a single human gatekeeper)
+during the current phase. PRs that need a new tone use the scale token
+in component code; the curator promotes to a semantic token in a
+later batch when a real pattern has emerged. Enforcement of this rule
+is convention only — no lint rule, no codemod tag — until component
+count grows past easy PR review.
+
+### Source-of-truth
+
+`docs/conventions/TOKEN-SYSTEM.md` holds the spec for every token:
+which palette and step it reads from in each context (base, each
+`[data-theme]`), and the rationale for any step-shifts. Encoded as
+tables per token domain so each token is one row, scannable and
+diff-friendly.
+
+CSS is the implementation. Agents and contributors are prompted to
+read TOKEN-SYSTEM.md first and treat it as the contract; if CSS
+disagrees with docs, the CSS is wrong.
+
+No automated drift detector ships with this decision. Drift is a real
+risk but bounded by the small token surface, the single curator, and
+the table format (which makes "did this PR update the doc?" a fast
+review question). The table-shaped spec is latent capability for a
+future script if drift becomes a felt pain — addable without
+restructuring the doc.
+
+## Alternatives considered
+
+### Keep the per-theme alias layer (status quo before this ADR)
+
+Rejected. The alias layer added a definition tier without adding a
+layer of meaning — every themed token had to be defined twice (base
+value + `--accent-X` alias) and remapped a third time in each
+`[data-theme]` block. The retargeting can be done directly under
+`[data-theme]` reading from the scale, achieving the same end-result
+with one fewer definition layer.
+
+### Accent-as-role indirection (`--accent-N` binding under :root)
+
+Rejected. This was a midpoint proposal: introduce a `--accent-1`
+through `--accent-12` set of variables under `:root`, bound to a
+specific palette (`--accent-3: var(--blue-3)`), and have semantic
+tokens read from `--accent-N`. The idea was that switching the
+app-level accent meant rebinding one set of 12 variables.
+
+In Ora's current model, there is only ever one accent active at a
+time at the app level, and themed components opt in per-component via
+`data-theme="accent"`. The `--accent-N` indirection would carry no
+runtime benefit (the rebinding still happens at the same place) and
+would introduce a token tier without a real consumer. Inline
+retargeting in `[data-theme]` blocks expresses the same intent more
+directly.
+
+### Pure scale exposure (no semantic layer)
+
+Rejected. Components reading `bg-gray-a3` / `bg-blue-a3` directly
+loses the semantic naming layer that makes intent legible at the read
+site. `bg-ui` says "this is a ui surface"; `bg-gray-a3` says "this is
+gray-3" and requires the reader to know that gray-3 is the ui-surface
+step. Worse, it forces theme-awareness into every component (each one
+would need to know which scale to read from per theme).
+
+### Drift detection script with CSS-inline waivers
+
+Rejected. Two reasons: (1) CSS files ship to end-user consumers via
+the shadcn registry, so inline comments would land in their codebase
+unless stripped at build time, adding tooling; (2) a hard
+key-parity rule does not match reality (some semantic tokens
+genuinely don't belong in `[data-theme]`), and waivers for every
+neutral surface token would dilute the signal.
+
+The docs-as-spec approach lets the spec express both expectations and
+intentional exceptions without polluting consumer-owned CSS.
+
+## Consequences
+
+**Positive:**
+
+- Semantic tokens have a principled foundation (Radix's step
+  semantics) rather than hand-picked values per token.
+- Adding a new themed semantic token = one definition under `:root` +
+  one line per `[data-theme]` block. Half the surface area of the
+  alias-layer approach.
+- Alpha-modifier escape hatches (`bg-ui/50`) become symptoms to
+  watch for — repeated reaches signal a missing semantic token.
+- Scale tokens are an honest escape hatch when no semantic fits,
+  rather than hidden alpha math.
+- One less token tier (`--accent-ui` etc. retired) → less to learn,
+  fewer places to update.
+
+**Negative:**
+
+- Drift risk between `:root` and `[data-theme]` blocks. Without an
+  alias layer, the connection between "base `--ui`" and
+  "accent `--ui`" is convention-enforced rather than structural. A
+  later drift script can mitigate, but ships with this ADR as a
+  deferred capability, not a built-in safeguard.
+- TOKEN-SYSTEM.md becomes load-bearing — it's the source of truth
+  for token spec, not just narrative. Drift between docs and CSS
+  becomes a real bug class.
+- Onus on the curator (single gatekeeper) to keep docs current with
+  CSS, and to make semantic-promotion calls. Bottleneck risk if the
+  curator's bandwidth shrinks.
+- Migration cost: globals.css needs restructuring; TOKEN-SYSTEM.md
+  needs rewriting; existing components keep working (they reference
+  semantic tokens which still exist) but the underlying definitions
+  shift wholesale.
+
+## Followups
+
+- **Phase 1 (additive prep, can ship anytime):** introduce scale tokens
+  in `globals.css` alongside the existing semantic + role-binding
+  setup. No behavior change; lets value choices be spot-checked in
+  isolation.
+- **Phase 2 (cut-over, one focused diff):** rewrite semantic tokens to
+  read from scale, retire the `--gray-ui` / `--accent-ui` / etc.
+  role-binding variables, rewrite `[data-theme]` blocks to retarget
+  inline. Phase 2 also promotes `--ui-subtle` (reads `--gray-a2` in
+  base, accent-2 under `[data-theme=accent]`) — the canonical example
+  of an alpha-modifier escape hatch becoming a real semantic token.
+- **Migration is independent of the eager Entry-schema migration
+  (ADR-0007).** They share no risk surface and should not be batched —
+  coupling them lets either's iteration block the other.
+- Rewrite `docs/conventions/TOKEN-SYSTEM.md` to use the table-per-
+  domain spec shape. Each token = one row with base step, theme
+  steps, notes for any step-shifts. Lands with Phase 2.
+- Add prompt-level guidance for agents (likely in `AGENTS.md` or a
+  token-focused convention doc) that says: read TOKEN-SYSTEM.md
+  first when touching tokens; treat it as the spec; update the doc
+  table in the same PR as any token change.
+- Audit existing `bg-ui/50`-style alpha modifier usage after Phase 2.
+  Each is a candidate for either a new semantic token (curator-
+  promoted) or a documented scale-direct reach.
+- Build a drift detection script if drift between docs and CSS
+  becomes felt pain. The table format is designed to support this
+  without restructuring.
+- **Scale source:** all scale values are custom-authored in Ora's
+  codebase. The Radix color generator is used as a sketching tool;
+  its output is vendored into Ora's `colors.css` as Ora's values, not
+  imported from `@radix-ui/colors`. Keeps full control over the
+  scale and avoids a runtime dependency.

--- a/docs/conventions/INDEX.md
+++ b/docs/conventions/INDEX.md
@@ -27,14 +27,16 @@ whether it supports theming.
 
 ### Theming via semantic tokens and data-theme
 
-Components use semantic tokens (--ui-1, --solid-1, --separator, --primary, etc.) that automatically adapt to the current theme. Theme switching happens at the CSS level through `[data-theme]` selectors, not through runtime JavaScript.
+Components use semantic tokens (--ui, --solid, --separator, --primary, etc.) that automatically adapt to the current theme. Theme switching happens at the CSS level through `[data-theme]` selectors, not through runtime JavaScript.
 
 **The pattern:**
 
 1. **Component uses semantic tokens** in Tailwind classes:
 
 ```tsx
-const buttonVariants = cva('text-ui-label bg-ui-1 hover:bg-ui-2 active:bg-ui-3 border-border-1');
+const buttonVariants = cva(
+  'text-ui-label bg-ui hover:bg-interactive-1 active:bg-interactive-2 border-border-1'
+);
 ```
 
 2. **Component sets data-theme attribute** (not style prop):
@@ -51,17 +53,17 @@ const buttonVariants = cva('text-ui-label bg-ui-1 hover:bg-ui-2 active:bg-ui-3 b
 ```css
 /* Default (gray) theme - no attribute needed */
 :root {
-  --ui-1: /* gray scale step */;
-  --solid-1: /* gray scale step */;
-  --ui-2: /* gray scale step */;
+  --ui: /* gray role token */;
+  --solid: /* gray role token */;
+  --interactive-1: /* gray role token */;
   /* ...the full 18-token set... */
 }
 
-/* Accent theme — same 18 slots, themed scale */
+/* Accent theme — same 18 slots, themed values */
 [data-theme='accent'] {
-  --ui-1: /* accent scale step */;
-  --solid-1: /* accent scale step */;
-  --ui-2: /* accent scale step */;
+  --ui: /* accent role token */;
+  --solid: /* accent role token */;
+  --interactive-1: /* accent role token */;
   /* ... */
 }
 ```
@@ -83,7 +85,7 @@ this pattern should be migrated to semantic tokens + data-theme.
 ### CVA variant definition
 
 CVA handles variant styles using semantic tokens — layout, sizing,
-spacing, and colors via token classes (bg-ui-1, text-primary, border-border-1).
+spacing, and colors via token classes (bg-ui, text-primary, border-border-1).
 
 Each component defines its own variant landscape. There is no global set —
 a button may offer solid/outline/surface/soft/ghost while a dropdown only
@@ -93,10 +95,10 @@ offers solid/soft. This is determined per component based on its needs.
 const buttonVariants = cva('text-ui-label rounded-dynamic focus-visible:outline-ring', {
   variants: {
     variant: {
-      solid: 'bg-solid-1 text-on-solid hover:bg-solid-2 active:bg-solid-2/90',
-      outline: 'border border-border-1 bg-transparent hover:bg-ui-1/30',
-      soft: 'bg-ui-1 hover:bg-ui-2 active:bg-ui-3',
-      ghost: 'hover:bg-ui-2 active:bg-ui-3',
+      solid: 'bg-solid text-on-solid hover:bg-solid-interactive active:bg-solid-interactive/90',
+      outline: 'border border-border-1 bg-transparent hover:bg-ui/30',
+      soft: 'bg-ui hover:bg-interactive-1 active:bg-interactive-2',
+      ghost: 'hover:bg-interactive-1 active:bg-interactive-2',
     },
     size: {
       sm: 'h-8 px-3 text-xs',
@@ -176,7 +178,7 @@ Use component-scoped CSS custom properties for open-ended visual
 customisation — values a user is likely to want to tweak but that don't
 warrant a named prop.
 
-Semantic tokens (`--ui-1`, `--solid-1`, `--primary`, etc.) already provide theme
+Semantic tokens (`--ui`, `--solid`, `--primary`, etc.) already provide theme
 customisation. Component-specific properties handle structural overrides:
 
 ```tsx
@@ -225,7 +227,7 @@ Tokens express intent. Use semantic tokens, never raw scale values.
 
 ```tsx
 // Good: semantic token — adapts to light/dark automatically
-className = 'bg-ui-2';
+className = 'bg-interactive-1';
 
 // Bad: raw scale value — breaks across themes
 className = 'bg-gray-100 dark:bg-gray-800';

--- a/docs/conventions/TOKEN-SYSTEM.md
+++ b/docs/conventions/TOKEN-SYSTEM.md
@@ -44,19 +44,23 @@ decision record.
 
 ## Domains
 
-The 18 semantic tokens group into six domains.
+The 18 semantic tokens group into six domains. Bare aliases
+(`--border`, `--interactive`) point at step 1 of their ladder for
+ergonomics and are not counted as separate slots.
 
 ### Background & Surfaces
 
 ```css
 --background   /* page/app floor */
+--subtle       /* solid, one notch above the floor */
 --surface-1    /* subtle raised container */
---surface-2    /* more raised */
---surface-3    /* most raised */
+--surface-2    /* most raised */
 --overlay      /* modals, popovers, floating elements */
 ```
 
-`--surface-N` is an ordinal ladder: 1 is the most subtle raise, 3 the
+`--subtle` is a solid surface a touch above `--background` — quieter
+than the raised `--surface-N` ladder (think code blocks, inset panels).
+`--surface-N` is an ordinal ladder: 1 is the most subtle raise, 2 the
 most raised. `--overlay` is distinct from the surface ladder — it
 matches `--background` in light mode and steps up to the first solid
 surface in dark mode, so floating elements read correctly against the
@@ -64,31 +68,37 @@ page in both.
 
 ### UI
 
-Soft interactive container backgrounds. Alpha-based so they layer over
-any surface, in three strength levels.
+Soft interactive container backgrounds, alpha-based so they layer over
+any surface. `--ui` is the resting container; `--interactive-N` are its
+interaction-state weights.
 
 ```css
---ui-1   /* resting soft container */
---ui-2   /* one step stronger */
---ui-3   /* strongest */
+--ui              /* resting soft container */
+--interactive-1   /* first interaction weight (e.g. hover) */
+--interactive-2   /* stronger interaction weight (e.g. active) */
+--interactive     /* alias → --interactive-1 */
 ```
 
-A component maps interaction states onto these levels by visual intent,
-not by a fixed state→token rule (see
-[Naming convention](#naming-convention-ordinal-strength-not-interaction-state)).
+The split is rest-vs-interaction, not a pure strength ladder: `--ui`
+is where a control sits, `--interactive-N` is where it goes when
+touched. Which state reads which level is a component decision (see
+[Naming convention](#naming-convention)).
 
 ### Solid
 
 Emphatic fill, for solid buttons, badges, and similar high-emphasis
-surfaces. Two strength levels.
+surfaces. A resting fill plus its interaction weight.
 
 ```css
---solid-1   /* resting solid fill */
---solid-2   /* stronger solid fill */
+--solid               /* resting solid fill */
+--solid-interactive   /* fill when interacted (e.g. hover) */
 ```
 
-Hover/active modulation on a solid surface is done with alpha against
-`--solid-2`, not with additional tokens.
+`--solid-interactive` replaces the old `bg-fill/90` hover hack. For the
+default (gray) palette it is a `color-mix` between the top two scale
+steps; themed palettes step up one scale step. Deeper states (active)
+are handled per-component via alpha or component vars, not a third
+token.
 
 ### Borders
 
@@ -98,6 +108,7 @@ Two kinds, and the value type _is_ the distinction.
 --separator   /* layout/structural lines — solid */
 --border-1    /* ui-element border — alpha */
 --border-2    /* stronger ui-element border — alpha */
+--border      /* alias → --border-1 */
 ```
 
 - `--separator` is **solid**. Use it for layout/structural lines:
@@ -126,8 +137,8 @@ Foreground rather than under their paired surface domain.
 ```css
 --primary     /* first-tier text/icon */
 --secondary   /* second-tier text/icon */
---ui-label    /* foreground when painting on a --ui-N surface */
---on-solid    /* foreground when painting on a --solid-N surface */
+--ui-label    /* foreground when painting on a --ui surface */
+--on-solid    /* foreground when painting on a --solid surface */
 ```
 
 `--primary` / `--secondary` are the two-tier hierarchy. `--ui-label`
@@ -137,34 +148,42 @@ under `[data-theme]`.
 
 ---
 
-## Naming convention: ordinal strength, not interaction state
+## Naming convention
 
-Tokens in a strength ladder (`--ui-N`, `--solid-N`, `--surface-N`,
-`--border-N`) are named by **intensity**, not by the interaction state
-they "belong to". A component maps any interaction state to any strength
-level based on visual intent.
+Two shapes, applied where each is honest:
+
+- **Ordinal strength** where a true intensity ladder exists:
+  `--surface-N`, `--border-N`. Named by intensity, not by the state
+  they "belong to" — a component maps any state to any level by visual
+  intent.
+- **Rest / interactive split** where the meaningful distinction is
+  interaction, not raw intensity: `--ui` vs `--interactive-N`, `--solid`
+  vs `--solid-interactive`. The resting token is where a control sits;
+  the interactive token(s) are where it goes when touched.
 
 ```tsx
-// Button: default mapping — hover steps up one, active steps up two
-'bg-ui-1 hover:bg-ui-2 active:bg-ui-3';
+// Soft container: rest, then interaction weights
+'bg-ui hover:bg-interactive-1 active:bg-interactive-2';
 
-// Toggle: pressed wants the hover weight, not a deeper one
-'data-[pressed]:bg-ui-2';
+// Toggle: pressed wants the first interaction weight, not the deepest
+'data-[pressed]:bg-interactive-1';
 
-// Tabs: selected wants the strongest weight this component has
-'data-[selected]:bg-ui-3';
+// Solid button: rest fill, hover steps to the interactive fill
+'bg-solid hover:bg-solid-interactive';
 ```
 
-The strength ladder is the contract; the state→strength mapping is a
-component decision. This is the explicit fix for the old `active/75`,
-`hover/50` escape-hatch family, where alpha was used to wrong-name a
-tone into a different state.
+Which state reads which token is a component decision. This replaces
+the old `active/75`, `hover/50`, `bg-fill/90` escape-hatch family, where
+alpha was used to wrong-name a tone into a different state. States
+beyond what the tokens name (e.g. a distinct `active` on a solid fill)
+are a component concern — handled via alpha modulation or component
+vars, not new system tokens.
 
 ---
 
 ## Escape hatches: alpha modifiers
 
-Components may use alpha modifiers (`bg-ui-1/50`, `bg-ui-2/50`,
+Components may use alpha modifiers (`bg-ui/50`, `bg-interactive-1/50`,
 `border-border-1/80`) for **subtle contextual modulation of the same
 role**. This is sanctioned, not a smell.
 
@@ -180,7 +199,7 @@ The line between sanctioned modulation and a missing token is **intent**:
   an adjacent affordance.
 - **Missing token** — reaching for a value that conceptually wants its
   own name. (The old `bg-fill/90` for solid-button hover was this; the
-  fix was to add `--solid-2`, not normalise the hack.)
+  fix was to add `--solid-interactive`, not normalise the hack.)
 
 Reviewers call out ambiguous cases during PR review.
 
@@ -196,15 +215,15 @@ code.
 ```css
 /* Default (gray) theme — no attribute needed */
 :root {
-  --ui-1: /* gray scale step */;
-  --solid-1: /* gray scale step */;
+  --ui: /* gray role token */;
+  --solid: /* gray role token */;
   /* ...the full 18-token set... */
 }
 
-/* Accent theme — same 18 slots, themed scale */
+/* Accent theme — same 18 slots, themed values */
 [data-theme='accent'] {
-  --ui-1: /* accent scale step */;
-  --solid-1: /* accent scale step */;
+  --ui: /* accent role token */;
+  --solid: /* accent role token */;
   /* ... */
 }
 ```
@@ -213,7 +232,7 @@ The fixed 18-token shape is what makes this work: every themed palette
 implements the **same** set of slots, so there's no asymmetric coverage
 and no silent fallback to gray. New themes — success, warning, a brand
 palette, or an entirely different aesthetic (game UI, expressive sites)
-— drop into the same shape by providing scale values for all 18 roles.
+— drop into the same shape by providing values for all 18 roles.
 
 ---
 
@@ -294,7 +313,7 @@ className = 'rounded-full';
 
 ## Open Questions
 
-- Whether additional surface levels beyond `--surface-3` are needed —
+- Whether additional surface levels beyond `--surface-2` are needed —
   deferred until concrete use cases arise.
 - Whether to add more theme palettes (success, warning, info) or keep a
   minimal set.


### PR DESCRIPTION
## What

Introduces the ADR-0008 semantic layer in `apps/www/registry/theme/globals.css` **alongside** the existing token names. Old tokens stay in place so components render identically; new tokens are available for subsequent component ports.

Refs #266.

## Token shape (18 slots)

| Domain | Tokens |
| --- | --- |
| Surfaces | `--background`, `--subtle`, `--surface-1`, `--surface-2`, `--overlay` |
| UI | `--ui`, `--interactive-1`, `--interactive-2` |
| Solid | `--solid`, `--solid-interactive` |
| Borders | `--separator`, `--border-1`, `--border-2` |
| Outline | `--ring` |
| Foreground | `--primary`, `--secondary`, `--ui-label`, `--on-solid` |

Bare aliases `--interactive` / `--border` map to step 1 (ergonomic, not counted in the 18).

## Notable decisions

- **Naming**: ordinal ladders where a true intensity ladder exists (`--surface-N`, `--border-N`); a rest/interactive split where interaction is the real distinction (`--ui`/`--interactive-N`, `--solid`/`--solid-interactive`). This refines ADR-0008's original pure-ordinal stance — the interaction problem lived in the old `--hover`/`--active` state tokens, not in `--ui`.
- **Raw values, not scale refs**: gray role tokens carry raw values; `--gray-solid-interactive` is a `color-mix` of the top two gray steps. Each `[data-theme]` palette declares its own `--*-solid-interactive` (hue-800) and `--*-border-2` (hue-a600) and reads them locally.
- **Additive**: legacy `--surface` / `--hover` / `--active` / `--fill` / `--line-ui` untouched (shiki + unported components keep working).
- `@theme inline` exposes all new tokens as utilities.

## Docs

Reconciled the count to 18 and the new naming across ADR-0008, TOKEN-SYSTEM, INDEX, and COMPONENT-GUIDE. (Also dropped the stray `surface-3` that made the prior "17" inconsistent.)

## Not in this PR — HITL eyeball pass

`--solid-interactive` and `--border-2` are first-pass values, **not yet visually reviewed**. Value review against button/dialog/dropdown/tabs (light + dark + themed) is deferred to the button-port task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)